### PR TITLE
feat: workspace-scoped skills with web UI and CLI (0.2.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ DSH 插件，可直接在 web 界面快速管理 skill 状态，同时在终端�
 - skill 状态：启用、停用状态标签，与内置插件列表同款样式
 - skill 管理：开关热启用/停用、删除；按名称搜索；进入页面自动刷新
 - skill 添加：选择单文件（`.md`）或目录束（含顶层 `SKILL.md` 的文件夹），不合规内容会被拒绝并提示原因
+- **工作区作用域**（0.2.6）：添加技能时可指定一个或多个工作区（默认全局）。
+  限定工作区的技能只在这些工作区的会话中可见，不会全局暴露；技能本体只存一份
+  （`~/.dsh/skills/.system/skill-viewer/<name>/`），每个绑定工作区的
+  `.dsh/skills/` 下是一个联接点。工作区被删除后联接点随之消失、绑定自动清理，
+  技能本身不会丢失（在页面中会提示"0 个工作区"）。卡片上的"作用域"按钮可随时
+  把技能在"全局 ↔ 限定工作区"之间切换。
 
 ## 安装
 
@@ -46,8 +52,11 @@ DSH 插件，可直接在 web 界面快速管理 skill 状态，同时在终端�
 随包附带 `dsh-skill` 命令，可直接在终端管理技能（同样热生效，网关关闭时也能用）：
 
 ```bash
-dsh-skill list                 # 列出技能（含启停状态）
+dsh-skill list                 # 列出技能（含启停状态与作用域）
 dsh-skill add <path>           # 添加技能（单个 .md 文件或含顶层 SKILL.md 的目录束）
+dsh-skill add <path> --workspace D:\项目A --workspace D:\项目B   # 限定到指定工作区
+dsh-skill scope <name> --global                    # 改为全局
+dsh-skill scope <name> --workspace D:\项目A        # 限定到指定工作区（可重复）
 dsh-skill disable <name>       # 停用
 dsh-skill enable <name>        # 启用
 dsh-skill delete <name>        # 删除（需确认）

--- a/bin/dsh-skill.js
+++ b/bin/dsh-skill.js
@@ -11,8 +11,11 @@
  *   dsh-skill delete <name> [--yes]    delete a skill permanently
  *   dsh-skill add <path>               add a skill (.md file, or a bundle dir
  *                                      whose top level contains SKILL.md)
+ *   dsh-skill scope <name>             change scope: --global | --workspace <path>...
  *   --cwd <path>                       project root anchor (default: current dir)
  *   --project                          add into the project root instead of ~/.dsh/skills
+ *   --workspace <path>                 add/scope the skill to a workspace
+ *                                      (repeatable; stored once, junction-linked)
  */
 import { copyFile, mkdir, readdir, readFile, rename, rm, stat } from "node:fs/promises";
 import { basename, dirname, join, resolve } from "node:path";
@@ -26,6 +29,18 @@ import {
   validateFrontmatter,
   winnerEntry
 } from "../lib/skill-files.js";
+import {
+  deleteScopedSkill,
+  ensureJunction,
+  loadBindings,
+  normalizeWorkspaces,
+  saveBindings,
+  scopeSkill,
+  scopedEnabled,
+  setScopedEnabled,
+  storeRoot,
+  storeSkillDir
+} from "../lib/scope.js";
 
 function usage() {
   console.log([
@@ -34,11 +49,16 @@ function usage() {
     "  dsh-skill enable <name> [--cwd <path>]                启用已停用的技能",
     "  dsh-skill disable <name> [--cwd <path>]               停用技能（改名 *.disabled，热生效）",
     "  dsh-skill delete <name> [--yes] [--cwd <path>]        删除技能（目录型删整个目录）",
-    "  dsh-skill add <path> [--cwd <path>] [--project]       添加技能：单个 .md 文件或含顶层 SKILL.md 的目录束",
+    "  dsh-skill add <path> [--cwd <path>] [--project] [--workspace <path>...]",
+    "                                                        添加技能：单个 .md 文件或含顶层 SKILL.md 的目录束",
+    "  dsh-skill scope <name> [--global | --workspace <path>...]",
+    "                                                        设置技能作用域：全局（默认）或限定工作区",
     "",
     "说明: 停用 = 把 SKILL.md 改名 SKILL.md.disabled；网关的监听器会热感知，",
-    "无需重启。add 默认写入 ~/.dsh/skills（--project 写入项目 .dsh/skills），",
-    "写入前完整校验并查重，任何一步失败都会自动回滚，不会留下半成品。",
+    "无需重启。add 默认写入 ~/.dsh/skills（--project 写入项目 .dsh/skills）。",
+    "限定工作区（--workspace）时技能只存一份（~/.dsh/skills/.system/skill-viewer），",
+    "在每个工作区的 .dsh/skills 下建立联接点，仅这些工作区的会话可见；",
+    "工作区删除后联接点随之消失、绑定自动清理，技能本身不会丢失。",
     "随部署附带的技能（bundled）不在本工具管理范围内。"
   ].join("\n"));
 }
@@ -92,6 +112,9 @@ async function walkFiles(dir, rel = "", out = []) {
  * duplicate name across all roots, destination conflicts, unsafe layouts).
  * The copy itself is staged inside the destination root and renamed into
  * place at the end, so any failure mid-write rolls back cleanly.
+ *
+ * With `workspaces` the skill is stored once in the managed store and
+ * junction-linked into each workspace's project `.dsh/skills` directory.
  */
 async function addSkill(sourceArg, flags, roots, entries) {
   const source = resolve(sourceArg);
@@ -118,24 +141,42 @@ async function addSkill(sourceArg, flags, roots, entries) {
     name = validation.skill.name;
   }
 
-  // 2) Destination root.
-  const destRoot = flags.project
-    ? roots.find((root) => root.source === "project-dsh")?.path
-    : join(userHomes().dshHome, "skills");
-  if (destRoot === undefined) throw new Error("找不到目标技能根（--project 需要当前目录锚定一个项目根）");
-  const target = kind === "bundle" ? join(destRoot, name) : join(destRoot, basename(source));
+  // 2) Destination root: project root, scoped store, or the user root.
+  const homes = userHomes();
+  const scoped = flags.workspaces !== undefined && flags.workspaces.length > 0;
+  let destRoot;
+  if (scoped) {
+    destRoot = storeSkillDir(homes.dshHome, name);
+  } else if (flags.project) {
+    destRoot = roots.find((root) => root.source === "project-dsh")?.path;
+    if (destRoot === undefined) throw new Error("找不到目标技能根（--project 需要当前目录锚定一个项目根）");
+  } else {
+    destRoot = join(homes.dshHome, "skills");
+  }
+  // Scoped skills always live in the store dir (store/<name>/SKILL.md) with a
+  // junction at each workspace's .dsh/skills/<name>; the original flat file
+  // name is kept in the binding so un-scoping can restore it.
+  const target = scoped
+    ? (kind === "bundle" ? destRoot : join(destRoot, "SKILL.md"))
+    : kind === "bundle" ? join(destRoot, name) : join(destRoot, basename(source));
 
   // 3) Duplicate + layout guards.
   const existing = winnerEntry(entries, name);
   if (existing !== undefined) throw new Error('同名技能 "' + name + '" 已存在（' + existing.source + "，" + (existing.enabled ? "已启用" : "已停用") + "）");
+  const bindings = await loadBindings(homes.dshHome);
+  if (bindings[name] !== undefined) throw new Error('同名技能 "' + name + '" 已存在（工作区限定）');
   if (await pathExists(target)) throw new Error("目标路径已存在：" + target);
   const resolvedRoot = resolve(destRoot);
   if (resolve(source) === resolve(target)) throw new Error("源路径与目标相同，无需添加：" + sourceArg);
   if (resolvedRoot.startsWith(resolve(source))) throw new Error("源路径不能是目标技能根本身或其上级目录：" + sourceArg);
 
   // 4) Staged copy + atomic rename; roll back on any failure.
-  await mkdir(destRoot, { recursive: true });
-  const staging = join(destRoot, ".dsh-skill-staging-" + process.pid + "-" + Math.random().toString(36).slice(2, 8));
+  // For scoped adds the store dir (store/<name>) is the destination of the
+  // bundle staging, so the staging directory lives OUTSIDE it; for flat adds
+  // the staged file is renamed to store/<name>/SKILL.md.
+  const stagingBase = kind === "bundle" ? dirname(target) : destRoot;
+  await mkdir(stagingBase, { recursive: true });
+  const staging = join(stagingBase, ".dsh-skill-staging-" + process.pid + "-" + Math.random().toString(36).slice(2, 8));
   try {
     if (kind === "bundle") {
       for (const file of await walkFiles(source)) {
@@ -155,12 +196,52 @@ async function addSkill(sourceArg, flags, roots, entries) {
     await rm(staging, { recursive: true, force: true }).catch(() => {});
     throw new Error("写入技能文件失败（已回滚）：" + (error instanceof Error ? error.message : String(error)));
   }
-  return { name, kind, target };
+
+  // 5) Workspace links + binding for scoped adds.
+  // The junction must point at the store DIRECTORY (store/<name>) — the same
+  // layout the provider discovers for both bundle and flat skills.
+  const created = [];
+  if (scoped) {
+    const workspaces = await normalizeWorkspaces(flags.workspaces);
+    if (workspaces.length === 0) throw new Error("至少需要指定一个存在的工作区");
+    const junctionTarget = destRoot;
+    try {
+      for (const workspace of workspaces) {
+        await ensureJunction(junctionTarget, join(workspace, ".dsh", "skills", name));
+        created.push(workspace);
+      }
+      bindings[name] = {
+        kind: kind === "bundle" ? "bundle" : "flat",
+        workspaces,
+        ...(kind === "flat" ? { fileName: basename(source) } : {})
+      };
+      await saveBindings(homes.dshHome, bindings);
+    } catch (error) {
+      for (const workspace of created) await rm(join(workspace, ".dsh", "skills", name), { recursive: true, force: true }).catch(() => {});
+      await rm(target, { recursive: true, force: true }).catch(() => {});
+      delete bindings[name];
+      throw new Error("绑定工作区失败（已回滚）：" + (error instanceof Error ? error.message : String(error)));
+    }
+    return { name, kind, target, scoped: true, workspaces: created };
+  }
+  return { name, kind, target, scoped: false };
+}
+
+/** Human-readable scope suffix for list output. */
+function scopeTag(entry, bindings) {
+  const binding = bindings[entry.name];
+  if (binding !== undefined && binding.workspaces !== undefined) {
+    const n = binding.workspaces.length;
+    if (n === 0) return " [0 个工作区]";
+    return " [" + n + " 个工作区]";
+  }
+  if (entry.source === "project-dsh" || entry.source === "project-agents") return " [项目]";
+  return " [全局]";
 }
 
 async function main() {
   const args = process.argv.slice(2);
-  const flags = { cwd: process.cwd(), yes: false, project: false };
+  const flags = { cwd: process.cwd(), yes: false, project: false, workspaces: [] };
   const positional = [];
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--cwd") {
@@ -170,8 +251,16 @@ async function main() {
         process.exit(2);
       }
       flags.cwd = args[i];
+    } else if (args[i] === "--workspace") {
+      i += 1;
+      if (i >= args.length) {
+        console.error("--workspace 需要一个路径参数");
+        process.exit(2);
+      }
+      flags.workspaces.push(args[i]);
     } else if (args[i] === "--yes") flags.yes = true;
     else if (args[i] === "--project") flags.project = true;
+    else if (args[i] === "--global") flags.global = true;
     else if (args[i] === "--help" || args[i] === "-h") {
       usage();
       return;
@@ -184,34 +273,112 @@ async function main() {
     process.exit(2);
   }
 
-  const roots = await buildRoots(flags.cwd, userHomes());
+  const homes = userHomes();
+  const roots = await buildRoots(flags.cwd, homes);
   const entries = await collectSkillEntries(roots);
+  const bindings = await loadBindings(homes.dshHome);
 
   if (command === "list") {
-    if (entries.length === 0) {
+    const all = [...entries];
+    for (const [managedName, binding] of Object.entries(bindings)) {
+      if (all.some((entry) => entry.name === managedName)) continue;
+      if (binding === undefined || binding.workspaces === undefined) continue;
+      all.push({
+        name: managedName,
+        description: "",
+        enabled: await scopedEnabled(homes.dshHome, managedName),
+        kind: "bundle",
+        file: join(storeSkillDir(homes.dshHome, managedName), "SKILL.md"),
+        dirBundle: true,
+        source: "user-dsh"
+      });
+    }
+    if (all.length === 0) {
       console.log("未找到技能。（搜索范围：项目 .dsh/skills、.agents/skills 与用户 ~/.dsh/skills、~/.agents/skills）");
       return;
     }
-    entries.sort((a, b) => a.name.localeCompare(b.name) || a.source.localeCompare(b.source));
-    for (const entry of entries) {
+    all.sort((a, b) => a.name.localeCompare(b.name) || a.source.localeCompare(b.source));
+    for (const entry of all) {
       const state = entry.enabled ? "启用" : "停用";
       const detail = entry.description.length > 70 ? entry.description.slice(0, 70) + "…" : entry.description;
-      console.log([state, entry.name, "[" + entry.source + "]", detail].filter(Boolean).join("	"));
+      console.log([state, entry.name, "[" + entry.source + "]" + scopeTag(entry, bindings), detail].filter(Boolean).join("\t"));
     }
     return;
   }
+
   if (command === "add") {
     if (name === undefined) {
       console.error("add 需要一个路径参数（单个 .md 文件或包含顶层 SKILL.md 的目录束）");
       process.exit(2);
     }
     const added = await addSkill(name, flags, roots, entries);
-    console.log('已添加技能 "' + added.name + '"（' + (added.kind === "bundle" ? "目录束" : "单文件") + " → " + added.target + "，网关监听器将热感知）");
+    if (added.scoped) {
+      console.log('已添加技能 "' + added.name + '"（限定工作区：' + added.workspaces.join("、") + " → " + added.target + "，网关监听器将热感知）");
+    } else {
+      console.log('已添加技能 "' + added.name + '"（' + (added.kind === "bundle" ? "目录束" : "单文件") + " → " + added.target + "，网关监听器将热感知）");
+    }
     return;
   }
+
+  if (command === "scope") {
+    if (name === undefined) {
+      console.error("scope 需要一个技能名参数");
+      process.exit(2);
+    }
+    if (flags.global && flags.workspaces.length > 0) {
+      console.error("--global 与 --workspace 不能同时使用");
+      process.exit(2);
+    }
+    const workspaces = flags.global ? null : flags.workspaces.length > 0 ? flags.workspaces : null;
+    if (!flags.global && flags.workspaces.length === 0) {
+      console.error("scope 需要 --global 或至少一个 --workspace <path>");
+      process.exit(2);
+    }
+    const binding = bindings[name];
+    let globalLocator;
+    if (binding === undefined) {
+      const entry = winnerEntry(entries, name);
+      if (entry === undefined || entry.source !== "user-dsh") throw new Error('技能 "' + name + '" 不在用户技能目录中，无法设置作用域');
+      globalLocator = entry;
+    }
+    await scopeSkill(homes.dshHome, name, workspaces, globalLocator);
+    if (workspaces === null) {
+      console.log('技能 "' + name + '" 已恢复为全局使用');
+    } else {
+      const resolved = await normalizeWorkspaces(workspaces);
+      console.log('技能 "' + name + '" 已限定到 ' + resolved.length + ' 个工作区：' + resolved.join("、"));
+    }
+    return;
+  }
+
   if (name === undefined) {
     console.error(command + " 需要一个技能名参数");
     process.exit(2);
+  }
+  const managed = bindings[name];
+  if (managed !== undefined && managed.workspaces !== undefined && (command === "enable" || command === "disable" || command === "delete")) {
+    if (command === "enable") {
+      await setScopedEnabled(homes.dshHome, name, true);
+      console.log('已启用技能 "' + name + '"（网关监听器将热感知，无需重启）');
+      return;
+    }
+    if (command === "disable") {
+      await setScopedEnabled(homes.dshHome, name, false);
+      console.log('已停用技能 "' + name + '"（网关监听器将热感知，无需重启）');
+      return;
+    }
+    if (command === "delete") {
+      if (!flags.yes) {
+        const ok = await confirm('确认删除技能 "' + name + '"？此操作不可恢复 (y/N): ');
+        if (!ok) {
+          console.log("已取消");
+          return;
+        }
+      }
+      await deleteScopedSkill(homes.dshHome, name);
+      console.log('已删除技能 "' + name + '"（含工作区联接点）');
+      return;
+    }
   }
   const entry = winnerEntry(entries, name);
   if (entry === undefined) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -18,10 +18,12 @@ window.__ModuleLoader__.load({
 		const cssCards = ".SKV_cards{grid-template-columns:repeat(2,minmax(0,1fr));align-items:start;gap:10px;margin:0;padding:0;list-style:none;display:grid}.SKV_card{border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-3);border-radius:10px;min-width:0;overflow:hidden}.SKV_card[data-open=true]{border-color:var(--dsw-alias-border-l1);box-shadow:var(--dsw-shadow-lv1)}.SKV_cardContent{width:100%;align-items:center;gap:8px;font:inherit;color:var(--dsw-alias-label-primary);cursor:pointer;background:0 0;border:none;padding:10px 12px;display:flex;text-align:left}.SKV_cardLeading{width:16px;height:16px;color:var(--dsw-alias-label-tertiary);flex:none;justify-content:center;align-items:center;display:inline-flex}.SKV_cardTitle{min-width:0;flex:1;text-overflow:ellipsis;white-space:nowrap;overflow:hidden;font-size:13px;font-weight:500;line-height:20px;transition:color .2s ease}.SKV_cardTitle[data-disabled=true]{color:var(--dsw-alias-label-tertiary)}.SKV_cardTrailing{color:var(--dsw-alias-label-tertiary);flex:none;align-items:center;gap:7px;display:inline-flex}.SKV_statusDot{background:var(--dsw-alias-label-tertiary);border-radius:999px;flex:none;width:7px;height:7px;display:inline-block;transition:background-color .2s ease}.SKV_statusDot[data-enabled=true]{background:var(--dsw-alias-state-success-primary)}.SKV_configTag{background:var(--dsw-alias-bg-layer-1);min-height:20px;color:var(--dsw-alias-label-secondary);white-space:nowrap;border-radius:5px;align-items:center;padding:1px 6px;font-size:11px;line-height:16px;display:inline-flex;transition:background-color .2s ease,color .2s ease}.SKV_configTag[data-enabled=true]{background:color-mix(in srgb, var(--dsw-alias-state-success-primary) 10%, transparent);color:var(--dsw-alias-state-success-primary)}.SKV_configTag[data-enabled=false]{color:var(--dsw-alias-label-tertiary)}.SKV_chevron{color:var(--dsw-alias-label-tertiary);flex:none;transition:transform .15s}.SKV_card[data-open=true] .SKV_chevron{transform:rotate(180deg)}.SKV_cardDetails{border-top:1px solid var(--dsw-alias-border-l2);flex-direction:column;gap:8px;padding:10px 12px;display:flex}.SKV_meta{color:var(--dsw-alias-label-secondary);font-size:12px;line-height:18px;margin:0}.SKV_metaProvider{color:var(--dsw-alias-label-tertiary);margin-left:6px}.SKV_contentBox{border:1px solid var(--dsw-alias-border-l1);background:var(--dsw-alias-markdown-code-block);border-radius:8px;max-height:213px;overflow:auto}.SKV_content{margin:0;padding:10px 12px;white-space:pre-wrap;word-break:break-word;color:var(--dsw-alias-label-primary);font-family:ui-monospace,SFMono-Regular,Consolas,Menlo,monospace;font-size:12px;line-height:18px}.SKV_failureText{color:var(--dsw-alias-state-error-primary);font-size:12px;line-height:18px;margin:0}.SKV_cardActions{border-top:1px solid var(--dsw-alias-border-l2);align-items:center;gap:8px;padding-top:10px;display:flex}.SKV_switchRow{align-items:center;gap:8px;display:inline-flex}.SKV_switch{box-sizing:border-box;width:36px;height:20px;border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-3);border-radius:999px;cursor:pointer;padding:0;position:relative;flex:none;transition:background-color .2s ease,border-color .2s ease}.SKV_switch:disabled{cursor:default;opacity:.6}.SKV_switch[data-on=true]{border-color:transparent;background:var(--dsw-alias-state-business-primary)}.SKV_switchThumb{box-sizing:border-box;width:14px;height:14px;border-radius:50%;background:var(--dsw-alias-label-secondary);position:absolute;top:2px;left:2px;transition:transform .22s cubic-bezier(.34,1.56,.64,1),background-color .18s ease,width .15s ease}.SKV_switch[data-on=true] .SKV_switchThumb{transform:translateX(18px);background:var(--dsw-alias-label-primary-foreground)}.SKV_switch:active:not(:disabled) .SKV_switchThumb{width:18px}.SKV_switch[data-on=true]:active:not(:disabled) .SKV_switchThumb{transform:translateX(14px)}.SKV_switchText{color:var(--dsw-alias-label-secondary);font-size:12px;line-height:18px}.SKV_opError{color:var(--dsw-alias-state-error-primary);font-size:12px;line-height:18px}.SKV_deleteButton{box-sizing:border-box;height:28px;color:var(--dsw-alias-state-error-primary);font:inherit;cursor:pointer;background:0 0;border:1px solid var(--dsw-alias-border-l2);border-radius:14px;padding:0 12px;font-size:12px;line-height:26px;margin-left:auto}.SKV_deleteButton:hover:not(:disabled){background:var(--dsw-alias-interactive-bg-hover-solid)}.SKV_deleteButton:disabled{cursor:default;opacity:.6}";
 		// 添加技能：按钮组与状态行
 		const cssAdd = ".SKV_addActions{margin-left:auto;align-items:center;gap:6px;display:inline-flex;position:relative}.SKV_addButton{box-sizing:border-box;width:28px;height:28px;color:var(--dsw-alias-label-primary);font:inherit;cursor:pointer;background:0 0;border:1px solid var(--dsw-alias-border-l2);border-radius:14px;padding:0;display:inline-flex;align-items:center;justify-content:center}.SKV_addButton:hover:not(:disabled){background:var(--dsw-alias-interactive-bg-hover-solid)}.SKV_addButton:disabled{cursor:default;opacity:.6}.SKV_addMenu{position:absolute;top:calc(100% + 4px);right:0;background:var(--dsw-alias-bg-layer-3);border:1px solid var(--dsw-alias-border-l1);border-radius:8px;box-shadow:var(--dsw-shadow-lv1);flex-direction:column;padding:4px;display:flex;z-index:10}.SKV_addMenuItem{font:inherit;color:var(--dsw-alias-label-primary);cursor:pointer;background:0 0;border:none;border-radius:6px;padding:6px 12px;font-size:13px;line-height:20px;text-align:left;white-space:nowrap}.SKV_addMenuItem:hover{background:var(--dsw-alias-interactive-bg-hover)}.SKV_addStatus{color:var(--dsw-alias-label-tertiary);font-size:12px;line-height:18px;margin:0}.SKV_addErrorBanner{border:1px solid color-mix(in srgb, var(--dsw-alias-state-error-primary) 40%, transparent);background:color-mix(in srgb, var(--dsw-alias-state-error-primary) 8%, transparent);border-radius:8px;align-items:center;gap:10px;padding:8px 12px;display:flex}.SKV_addErrorText{color:var(--dsw-alias-state-error-primary);font-size:12px;line-height:18px;flex:1;min-width:0}.SKV_addDismiss{font:inherit;color:var(--dsw-alias-label-primary);cursor:pointer;background:0 0;border:1px solid var(--dsw-alias-border-l2);border-radius:6px;padding:2px 10px;font-size:12px;line-height:18px;flex:none}.SKV_addDismiss:hover{background:var(--dsw-alias-interactive-bg-hover-solid)}.SKV_fileInput{display:none}";
+		// 作用域：卡片标签、作用域编辑弹层
+		const cssScope = ".SKV_scopeTag{background:var(--dsw-alias-bg-layer-1);min-height:20px;color:var(--dsw-alias-label-secondary);white-space:nowrap;border-radius:5px;align-items:center;padding:1px 6px;font-size:11px;line-height:16px;display:inline-flex}.SKV_scopeTag[data-scoped=true]{background:color-mix(in srgb, var(--dsw-alias-state-business-primary) 12%, transparent);color:var(--dsw-alias-state-business-primary)}.SKV_scopeTag[data-scoped=true][data-zero=true]{background:color-mix(in srgb, var(--dsw-alias-state-warning-primary) 12%, transparent);color:var(--dsw-alias-state-warning-primary)}.SKV_scopeEditButton{font:inherit;color:var(--dsw-alias-label-secondary);cursor:pointer;background:0 0;border:1px solid var(--dsw-alias-border-l2);border-radius:6px;padding:3px 10px;font-size:12px;line-height:18px}.SKV_scopeEditButton:hover{background:var(--dsw-alias-interactive-bg-hover-solid)}.SKV_scopeOverlay{position:fixed;inset:0;background:color-mix(in srgb, rgba(0,0,0,.45) 55%, transparent);align-items:center;justify-content:center;display:flex;z-index:1000}.SKV_scopeBox{background:var(--dsw-alias-bg-layer-3);border:1px solid var(--dsw-alias-border-l1);border-radius:12px;box-shadow:var(--dsw-shadow-lv2);width:440px;max-width:calc(100vw - 48px);max-height:80vh;flex-direction:column;padding:16px;gap:12px;display:flex}.SKV_scopeBox h4{font-size:14px;font-weight:600;line-height:20px;margin:0}.SKV_scopeOptions{flex-direction:column;gap:8px;display:flex}.SKV_scopeOption{font:inherit;color:var(--dsw-alias-label-primary);cursor:pointer;background:var(--dsw-alias-bg-layer-1);border:1px solid var(--dsw-alias-border-l2);border-radius:8px;padding:8px 12px;font-size:13px;line-height:20px;text-align:left;display:flex;align-items:center;gap:8px}.SKV_scopeOption[data-active=true]{border-color:var(--dsw-alias-state-business-primary);box-shadow:0 0 0 1px color-mix(in srgb, var(--dsw-alias-state-business-primary) 30%, transparent)}.SKV_scopeOption input{margin:0;accent-color:var(--dsw-alias-state-business-primary)}.SKV_wsList{flex-direction:column;gap:4px;max-height:200px;overflow:auto;padding:0;margin:0;list-style:none;display:flex}.SKV_wsItem{font:inherit;color:var(--dsw-alias-label-primary);cursor:pointer;background:0 0;border:none;border-radius:6px;padding:5px 8px;font-size:12px;line-height:18px;text-align:left;display:flex;align-items:center;gap:8px}.SKV_wsItem:hover{background:var(--dsw-alias-interactive-bg-hover)}.SKV_wsItem input{margin:0;flex:none;accent-color:var(--dsw-alias-state-business-primary)}.SKV_wsPath{color:var(--dsw-alias-label-tertiary);min-width:0;text-overflow:ellipsis;white-space:nowrap;overflow:hidden}.SKV_manualRow{align-items:center;gap:6px;display:flex}.SKV_manualInput{flex:1;border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-1);height:30px;color:var(--dsw-alias-label-primary);font:inherit;border-radius:6px;outline:none;padding:0 8px;font-size:12px}.SKV_manualInput:focus-visible{border-color:var(--dsw-alias-state-business-primary)}.SKV_manualAdd{font:inherit;color:var(--dsw-alias-label-primary);cursor:pointer;background:var(--dsw-alias-bg-layer-1);border:1px solid var(--dsw-alias-border-l2);border-radius:6px;padding:3px 10px;font-size:12px;flex:none}.SKV_scopeHint{color:var(--dsw-alias-label-tertiary);font-size:12px;line-height:18px;margin:0}.SKV_scopeWarning{color:var(--dsw-alias-state-warning-primary);font-size:12px;line-height:18px;margin:0}.SKV_scopeActions{align-items:center;justify-content:flex-end;gap:8px;display:flex}.SKV_scopeAction{font:inherit;cursor:pointer;border-radius:6px;padding:5px 14px;font-size:13px;line-height:20px}.SKV_scopeCancel{background:0 0;border:1px solid var(--dsw-alias-border-l2);color:var(--dsw-alias-label-primary)}.SKV_scopeConfirm{background:var(--dsw-alias-state-business-primary);border:1px solid transparent;color:var(--dsw-alias-state-business-on-primary, #fff)}.SKV_scopeConfirm:disabled{opacity:.6;cursor:default}";
 		const cssUtils = ".SKV_visuallyHidden{position:absolute;width:1px;height:1px;margin:-1px;padding:0;border:0;clip:rect(0 0 0 0);overflow:hidden;white-space:nowrap}";
 		// 设置页导航图标（外壳硬编码图标，无扩展点：打标记 + CSS 蒙版绘制）
 		const cssIcon = "button[data-skills-nav]>svg{display:none}button[data-skills-nav]::before{content:\"\";width:16px;height:16px;flex:none;display:inline-block;background-color:currentColor;-webkit-mask:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAfxSURBVHhe7Vtbq2RHFY5JUIPXaIh4efBdAl6iDyFM4pNEIoLgPzAmoCBkjAFBQx589Af4mssQEBI1JoJnxpnM0dwmo4LOJRNfzJmZZAjMOWeOPb2+tdauHVZ1VXftNd3n9Om9d59DzAeLql27dl2+XmtV1dq7r7vufbyPuSEi94jI48xyGsBbAN6OQllodN2US8zsyyZizxXXInKBmZ/a3Ayf9v3vGba2tj6jzH+olwhV/efW1tatfixLh01eRE7boJi5BuDH2hmIKGSxa2b+x5UrV27xY1oqADwfBzccBhWJA2XwRRE5zsyHARxh4AiAv5gwc8yP06KcEcuO2HP2TK4D4LBATjBzABBAFMX6EpGTGxsbn/LjWgqGw+G30i9RC0tdVZWp5sEQwsd93bYIIdwWJ2xalgjImiCqJ/dEE4joUFbNlP7C1+kKzHx7HUIkIPcXQoialzThRAhhuZoA4GweCIPfuXTp0kd9nUVR1/UHTPI1M389VEaAmJaZrzHzeGdkfmNzOLG+Xn+y2VKPAHAhGr2ZAfHf/f0uwQO+3UzMCEhm9yMAX1XV/zkSXqvr+mb/fC8AcL4g4DV/v0sw89dCk4BfWvlwOLxbVbdGJIzN4eWlOEYG1goC+tUAbmoAMUUCDFevXr1LVQeOhFcuX778iWYrHaNBAPeuAYkAzv1Fh5v9hAzFNCGaw7Agoa7r/khg5jEBAF7197uEmUBDA4geyfcyCaU5FCS81Js5lD6AiE74+12Cmb8RV5ukAZkAv1okc7hGE9bX17tfHUoC+taAAQ9GBKStNtHIB5STzzASKq0ajlFFX63rjpfIBgE9awCAr1Q68QEAfmXlXgMykjkkxzhaIlX1lc3Nze5OkbxEExgMBp8DcNX8QCLgZV/HUBIiIt8c7xPS7tFI2NjY6Gaf4EygVwIMAP6a+hpNhvlBX8cDwJdV9WKlWhONnrMdYyckLHMjZADw/dgXMHaGzPykiHw3hHAHM9/JzAeSWP5OMx1bMkVE4mlycoq0JbIdCctcBTIY+K31B5qQsBMACIj0mlOkyIutTq57QUBd1x9m5t/nfk0bLAhjZETBKDVnWV6DJnGEMp5ARI/5PuaGc4K9m0AJVf1xVem53P9uYKtJ1gIAF33bc6MkANS/E/QIIXwohHBAVR9Q1oeY+SFV/amlSSz/M2Z+OKUPKutBZn7TjtSJgPO+3bnR3Acsn4BFAWB1PO42BDCWdxYo4Tc+0zZDuayUfA/AS8W418rndgXnBHslwE/Cw9/3k59FgP2I40Z2i2VuhXdCOcntiDIAeHE87jYm0NQAPunv942dJjoLoNIEuCsCaOkELIqGCXALE2DmyVa454hQlxBI6QQX14DmRmhiAtNUczgcflFEDgF4Ib3tOQrCUSI6NkpxDBgJEa0S0XEiesHuWwqKz42EsArgeK6fyo+LyN+qqnraXqL4/kt05gMYEw0oT4PTCMiv0JYBe2dY1/X1fgwZdpTOdUG44O/PDXs4N1SeBWYQcGw8wp7BzG/UdX2DH0OG8wGLa4BzgmMfMGPtvU1VV1T1NDNPBEgp2zcFlj/DzKcAnErlZ4TFyk/J5DnLnxKWKHbNjLMicrbSalVE7h4Pcgq6M4EiKkxFPMBP3qMg6PqSrCllls9SXk+rf8N2v3qJhgm0IaCxEVpCRKgrdKYBto/ODe3FMug1bTutK9HcCHVFwIyQmB/kfoA7DLUiYFcmEEL4Ugjhrhy3Cxxy/O6AxfKLeF6ZnynWlgU9fT87AdTwAS12gsU+YKeQGDM/UFVVjMJ0DQC/9v1th840wBHQMAGv9sz879hhCmZuKymOd424cmsrTeKKRYfK/sqVoiw3EJFFhNsTUJrAdj7AUnuTk+t2DSJ6ctpEZ5HglsHFTWBeH5AHICL3WvyOmX+owH2WArgPwA8sZeb7k1h5LMtS1I352Ibq/SLyvbqub/R9bgcQdWMC74XjcCsCSh/Q9T5glvp2gc7iAQ0f0DEBfYKIxj6gSwL2hQnMozHUhw/wYXGvwoPB4AtVVf1GVf/E4OcsPpDE8n8E8KyJvfZK+Xi/qiore6Su6w+W7c/CPASg1IDuYoITAvzkDcz8u1x3ETDt/CrcMBcBjbB4Cw1ovBgp3gxNIwBE8d3+ohCRR8cdtwSIOjoNEk01gZKATIJ95aWqq8x8DsDrAM4xOKYpf8Y+vbV7KShi16+rql0f2s2XXp58j3Ij1EoDytOgD4nNGkQKXNzoxMossBGDGl58G21R+oB2GjBjGZxGwDQy9gpuK7x4ULT8UnTaVtgT4EnxKOtsV68tOiNgnoBIxryTWhIB5WlwcQLMcVkj6f8Cb4cQbvJ1Suw0qXLifZFgY7R/n9mYEwFv+Dpzg4ieio1Mvrf5ua+z30BEB9PE8ycyz/g6c4OI7o3qDw4WoFDRoKoPhxA+5uvuNUIIH1HVn6iqfTEXgyvpR/uOr7srENGKNWQfJquMv7tZS+///gxghS0l+H+QWRrLkqwU+XjN4BVQfOZwzI/qWJk9NxIiEyuze9Zf7DOLjS+1918bm30blL8fJqKjfj67RgjhsyJir6IiqzlMtR9BRONfnpn/Y5/f+vksBGtIVZ/zHe5XqOrzg8Hg834erUFE3xaRx5j5X7ZHsI1SFIqpXa8RUb4+b3lK+SRrIBrVSfWz2LnDnkv3zoPoQvHcNX2M68UyftPeH1ZV9URrm/9/w7uta8ACW3GakwAAAABJRU5ErkJggg==) center/16px 16px no-repeat;mask:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAfxSURBVHhe7Vtbq2RHFY5JUIPXaIh4efBdAl6iDyFM4pNEIoLgPzAmoCBkjAFBQx589Af4mssQEBI1JoJnxpnM0dwmo4LOJRNfzJmZZAjMOWeOPb2+tdauHVZ1VXftNd3n9Om9d59DzAeLql27dl2+XmtV1dq7r7vufbyPuSEi94jI48xyGsBbAN6OQllodN2US8zsyyZizxXXInKBmZ/a3Ayf9v3vGba2tj6jzH+olwhV/efW1tatfixLh01eRE7boJi5BuDH2hmIKGSxa2b+x5UrV27xY1oqADwfBzccBhWJA2XwRRE5zsyHARxh4AiAv5gwc8yP06KcEcuO2HP2TK4D4LBATjBzABBAFMX6EpGTGxsbn/LjWgqGw+G30i9RC0tdVZWp5sEQwsd93bYIIdwWJ2xalgjImiCqJ/dEE4joUFbNlP7C1+kKzHx7HUIkIPcXQoialzThRAhhuZoA4GweCIPfuXTp0kd9nUVR1/UHTPI1M389VEaAmJaZrzHzeGdkfmNzOLG+Xn+y2VKPAHAhGr2ZAfHf/f0uwQO+3UzMCEhm9yMAX1XV/zkSXqvr+mb/fC8AcL4g4DV/v0sw89dCk4BfWvlwOLxbVbdGJIzN4eWlOEYG1goC+tUAbmoAMUUCDFevXr1LVQeOhFcuX778iWYrHaNBAPeuAYkAzv1Fh5v9hAzFNCGaw7Agoa7r/khg5jEBAF7197uEmUBDA4geyfcyCaU5FCS81Js5lD6AiE74+12Cmb8RV5ukAZkAv1okc7hGE9bX17tfHUoC+taAAQ9GBKStNtHIB5STzzASKq0ajlFFX63rjpfIBgE9awCAr1Q68QEAfmXlXgMykjkkxzhaIlX1lc3Nze5OkbxEExgMBp8DcNX8QCLgZV/HUBIiIt8c7xPS7tFI2NjY6Gaf4EygVwIMAP6a+hpNhvlBX8cDwJdV9WKlWhONnrMdYyckLHMjZADw/dgXMHaGzPykiHw3hHAHM9/JzAeSWP5OMx1bMkVE4mlycoq0JbIdCctcBTIY+K31B5qQsBMACIj0mlOkyIutTq57QUBd1x9m5t/nfk0bLAhjZETBKDVnWV6DJnGEMp5ARI/5PuaGc4K9m0AJVf1xVem53P9uYKtJ1gIAF33bc6MkANS/E/QIIXwohHBAVR9Q1oeY+SFV/amlSSz/M2Z+OKUPKutBZn7TjtSJgPO+3bnR3Acsn4BFAWB1PO42BDCWdxYo4Tc+0zZDuayUfA/AS8W418rndgXnBHslwE/Cw9/3k59FgP2I40Z2i2VuhXdCOcntiDIAeHE87jYm0NQAPunv942dJjoLoNIEuCsCaOkELIqGCXALE2DmyVa454hQlxBI6QQX14DmRmhiAtNUczgcflFEDgF4Ib3tOQrCUSI6NkpxDBgJEa0S0XEiesHuWwqKz42EsArgeK6fyo+LyN+qqnraXqL4/kt05gMYEw0oT4PTCMiv0JYBe2dY1/X1fgwZdpTOdUG44O/PDXs4N1SeBWYQcGw8wp7BzG/UdX2DH0OG8wGLa4BzgmMfMGPtvU1VV1T1NDNPBEgp2zcFlj/DzKcAnErlZ4TFyk/J5DnLnxKWKHbNjLMicrbSalVE7h4Pcgq6M4EiKkxFPMBP3qMg6PqSrCllls9SXk+rf8N2v3qJhgm0IaCxEVpCRKgrdKYBto/ODe3FMug1bTutK9HcCHVFwIyQmB/kfoA7DLUiYFcmEEL4Ugjhrhy3Cxxy/O6AxfKLeF6ZnynWlgU9fT87AdTwAS12gsU+YKeQGDM/UFVVjMJ0DQC/9v1th840wBHQMAGv9sz879hhCmZuKymOd424cmsrTeKKRYfK/sqVoiw3EJFFhNsTUJrAdj7AUnuTk+t2DSJ6ctpEZ5HglsHFTWBeH5AHICL3WvyOmX+owH2WArgPwA8sZeb7k1h5LMtS1I352Ibq/SLyvbqub/R9bgcQdWMC74XjcCsCSh/Q9T5glvp2gc7iAQ0f0DEBfYKIxj6gSwL2hQnMozHUhw/wYXGvwoPB4AtVVf1GVf/E4OcsPpDE8n8E8KyJvfZK+Xi/qiore6Su6w+W7c/CPASg1IDuYoITAvzkDcz8u1x3ETDt/CrcMBcBjbB4Cw1ovBgp3gxNIwBE8d3+ohCRR8cdtwSIOjoNEk01gZKATIJ95aWqq8x8DsDrAM4xOKYpf8Y+vbV7KShi16+rql0f2s2XXp58j3Ij1EoDytOgD4nNGkQKXNzoxMossBGDGl58G21R+oB2GjBjGZxGwDQy9gpuK7x4ULT8UnTaVtgT4EnxKOtsV68tOiNgnoBIxryTWhIB5WlwcQLMcVkj6f8Cb4cQbvJ1Suw0qXLifZFgY7R/n9mYEwFv+Dpzg4ieio1Mvrf5ua+z30BEB9PE8ycyz/g6c4OI7o3qDw4WoFDRoKoPhxA+5uvuNUIIH1HVn6iqfTEXgyvpR/uOr7srENGKNWQfJquMv7tZS+///gxghS0l+H+QWRrLkqwU+XjN4BVQfOZwzI/qWJk9NxIiEyuze9Zf7DOLjS+1918bm30blL8fJqKjfj67RgjhsyJir6IiqzlMtR9BRONfnpn/Y5/f+vksBGtIVZ/zHe5XqOrzg8Hg834erUFE3xaRx5j5X7ZHsI1SFIqpXa8RUb4+b3lK+SRrIBrVSfWz2LnDnkv3zoPoQvHcNX2M68UyftPeH1ZV9URrm/9/w7uta8ACW3GakwAAAABJRU5ErkJggg==) center/16px 16px no-repeat}body[data-ds-dark-theme] .SKV_switchThumb{background:#fff}body[data-ds-dark-theme] .SKV_switch[data-on=true] .SKV_switchThumb{background:#fff}";
-		const css = cssChrome + cssCards + cssAdd + cssUtils + cssIcon;
+		const css = cssChrome + cssCards + cssAdd + cssScope + cssUtils + cssIcon;
 		const tagId = "dsh-skill-viewer/SkillsSection.module.css";
 		if (typeof document !== "undefined" && document.querySelector("style[data-plugin-css=" + JSON.stringify(tagId) + "]") === null) {
 			const tag = document.createElement("style");
@@ -70,7 +72,25 @@ window.__ModuleLoader__.load({
 			addErrorText: "SKV_addErrorText",
 			addDismiss: "SKV_addDismiss",
 			fileInput: "SKV_fileInput",
-			visuallyHidden: "SKV_visuallyHidden"
+			visuallyHidden: "SKV_visuallyHidden",
+			scopeTag: "SKV_scopeTag",
+			scopeEditButton: "SKV_scopeEditButton",
+			scopeOverlay: "SKV_scopeOverlay",
+			scopeBox: "SKV_scopeBox",
+			scopeOptions: "SKV_scopeOptions",
+			scopeOption: "SKV_scopeOption",
+			wsList: "SKV_wsList",
+			wsItem: "SKV_wsItem",
+			wsPath: "SKV_wsPath",
+			manualRow: "SKV_manualRow",
+			manualInput: "SKV_manualInput",
+			manualAdd: "SKV_manualAdd",
+			scopeHint: "SKV_scopeHint",
+			scopeWarning: "SKV_scopeWarning",
+			scopeActions: "SKV_scopeActions",
+			scopeAction: "SKV_scopeAction",
+			scopeCancel: "SKV_scopeCancel",
+			scopeConfirm: "SKV_scopeConfirm"
 		};
 
 		// ── locale ─────────────────────────────────────────────────────────────
@@ -105,7 +125,22 @@ window.__ModuleLoader__.load({
 			addBusy: "正在添加技能…",
 			addTooMany: "所选内容文件数量过多。",
 			addFolderUnsupported: "当前浏览器不支持选择文件夹，请改用“选择技能文件”。",
-			addNoSkillFile: "所选文件夹不是有效的技能目录：缺少顶层的 SKILL.md 文件。"
+			addNoSkillFile: "所选文件夹不是有效的技能目录：缺少顶层的 SKILL.md 文件。",
+			scopeGlobal: "全局",
+			scopeScopedPrefix: "",
+			scopeScopedSuffix: " 个工作区",
+			scopeEditLabel: "作用域",
+			scopeDialogTitle: "技能作用域",
+			scopeGlobalOption: "全局（所有工作区可用）",
+			scopeScopedOption: "仅限以下工作区",
+			scopeNoWorkspaces: "暂无已打开的工作区，可在下方手动输入路径",
+			scopeManualPlaceholder: "手动输入工作区路径",
+			scopeManualAdd: "添加",
+			scopeConfirm: "确认",
+			scopeCancel: "取消",
+			scopeSave: "保存",
+			scopeSaving: "正在保存作用域…",
+			scopeZeroWarning: "该技能当前没有任何生效的工作区，所有会话都看不到它。请重新选择工作区或改为全局。"
 		};
 
 		const en = {
@@ -137,7 +172,22 @@ window.__ModuleLoader__.load({
 			addBusy: "Adding skill…",
 			addTooMany: "Too many files in the selection.",
 			addFolderUnsupported: "This browser cannot pick folders — use Choose skill file instead.",
-			addNoSkillFile: "Not a valid skill folder: missing a top-level SKILL.md file."
+			addNoSkillFile: "Not a valid skill folder: missing a top-level SKILL.md file.",
+			scopeGlobal: "Global",
+			scopeScopedPrefix: "",
+			scopeScopedSuffix: " workspaces",
+			scopeEditLabel: "Scope",
+			scopeDialogTitle: "Skill scope",
+			scopeGlobalOption: "Global (available in every workspace)",
+			scopeScopedOption: "Only these workspaces",
+			scopeNoWorkspaces: "No workspaces seen yet — enter a path manually below",
+			scopeManualPlaceholder: "Enter a workspace path",
+			scopeManualAdd: "Add",
+			scopeConfirm: "Confirm",
+			scopeCancel: "Cancel",
+			scopeSave: "Save",
+			scopeSaving: "Saving scope…",
+			scopeZeroWarning: "This skill has no effective workspace right now — no session can see it. Pick workspaces again or switch to Global."
 		};
 
 		// ── remote contribution ───────────────────────────────────────────────
@@ -158,6 +208,28 @@ window.__ModuleLoader__.load({
 						{ name: "sessionId", wire: "sessionId", source: "json", acceptsUndefined: true, codec: codec("dsh-skill-viewer#sessionId") }
 					],
 					result: codec("dsh-skill-viewer#SkillListResult")
+				},
+				{
+					id: "dsh-skill-viewer#skillsViewer/workspaces",
+					service: "skillsViewer",
+					namespace: "skillsViewer",
+					method: "workspaces",
+					invocation: { kind: "direct" },
+					parameters: [],
+					result: codec("dsh-skill-viewer#WorkspacesResult")
+				},
+				{
+					id: "dsh-skill-viewer#skillsViewer/setScope",
+					service: "skillsViewer",
+					namespace: "skillsViewer",
+					method: "setScope",
+					invocation: { kind: "direct" },
+					parameters: [
+						{ name: "name", wire: "name", source: "json", codec: codec("dsh-skill-viewer#SkillName") },
+						{ name: "sessionId", wire: "sessionId", source: "json", acceptsUndefined: true, codec: codec("dsh-skill-viewer#sessionId") },
+						{ name: "workspaces", wire: "workspaces", source: "json", codec: codec("dsh-skill-viewer#WorkspaceList") }
+					],
+					result: codec("dsh-skill-viewer#SetScopeResult")
 				},
 				{
 					id: "dsh-skill-viewer#skillsViewer/content",
@@ -211,8 +283,158 @@ window.__ModuleLoader__.load({
 			]
 		};
 
+		// ── 作用域选择对话框（添加技能与编辑作用域共用）─────────────────────
+		function ScopeDialog({ t, options, initial, busy, onConfirm, onCancel }) {
+			const initialPaths = initial !== null && initial !== undefined && initial.kind === "workspaces" && Array.isArray(initial.workspaces) ? initial.workspaces.map((workspace) => workspace.path) : [];
+			const [mode, setMode] = react.useState(initialPaths.length > 0 ? "scoped" : "global");
+			const [selected, setSelected] = react.useState(initialPaths);
+			const [manual, setManual] = react.useState("");
+			const known = Array.isArray(options) ? options : [];
+			const extras = selected.filter((path) => !known.some((option) => option.path.toLowerCase() === path.toLowerCase()));
+			const togglePath = (path) => {
+				setSelected((prev) => prev.includes(path) ? prev.filter((item) => item !== path) : [...prev, path]);
+			};
+			const addManual = () => {
+				const value = manual.trim();
+				if (value === "") return;
+				setSelected((prev) => prev.some((item) => item.toLowerCase() === value.toLowerCase()) ? prev : [...prev, value]);
+				setManual("");
+			};
+			const submit = () => {
+				if (mode === "scoped" && selected.length === 0) return;
+				onConfirm(mode === "global" ? null : selected);
+			};
+			const labelOf = (path) => {
+				const parts = path.replaceAll("\\", "/").split("/").filter(Boolean);
+				return parts.length > 0 ? parts[parts.length - 1] : path;
+			};
+			return (0, react_jsx_runtime.jsx)("div", {
+				className: c.scopeOverlay,
+				role: "dialog",
+				"aria-modal": "true",
+				children: (0, react_jsx_runtime.jsxs)("div", {
+					className: c.scopeBox,
+					children: [(0, react_jsx_runtime.jsx)("h4", { children: t("scopeDialogTitle") }), (0, react_jsx_runtime.jsxs)("div", {
+						className: c.scopeOptions,
+						children: [(0, react_jsx_runtime.jsxs)("button", {
+							type: "button",
+							className: c.scopeOption,
+							"data-active": mode === "global" ? "true" : void 0,
+							onClick: () => {
+								setMode("global");
+							},
+							children: [(0, react_jsx_runtime.jsx)("input", {
+								type: "radio",
+								name: "scope-mode",
+								checked: mode === "global",
+								readOnly: true
+							}), (0, react_jsx_runtime.jsx)("span", { children: t("scopeGlobalOption") })]
+						}), (0, react_jsx_runtime.jsxs)("button", {
+							type: "button",
+							className: c.scopeOption,
+							"data-active": mode === "scoped" ? "true" : void 0,
+							onClick: () => {
+								setMode("scoped");
+							},
+							children: [(0, react_jsx_runtime.jsx)("input", {
+								type: "radio",
+								name: "scope-mode",
+								checked: mode === "scoped",
+								readOnly: true
+							}), (0, react_jsx_runtime.jsx)("span", { children: t("scopeScopedOption") })]
+						})]
+					}), mode === "scoped" ? known.length === 0 && extras.length === 0 ? (0, react_jsx_runtime.jsx)("p", {
+						className: c.scopeHint,
+						children: t("scopeNoWorkspaces")
+					}) : (0, react_jsx_runtime.jsxs)("ul", {
+						className: c.wsList,
+						children: known.map((option) => {
+							const checked = selected.includes(option.path);
+							return (0, react_jsx_runtime.jsxs)("li", {
+								key: option.path,
+								children: [(0, react_jsx_runtime.jsxs)("button", {
+									type: "button",
+									className: c.wsItem,
+									onClick: () => {
+										togglePath(option.path);
+									},
+									children: [(0, react_jsx_runtime.jsx)("input", {
+										type: "checkbox",
+										checked,
+										readOnly: true
+									}), (0, react_jsx_runtime.jsx)("span", { children: option.label }), (0, react_jsx_runtime.jsx)("span", {
+										className: c.wsPath,
+										title: option.path,
+										children: option.path
+									})]
+								})]
+							}, option.path);
+						}).concat(extras.map((path) => (0, react_jsx_runtime.jsxs)("li", {
+							key: path,
+							children: [(0, react_jsx_runtime.jsxs)("button", {
+								type: "button",
+								className: c.wsItem,
+								onClick: () => {
+									togglePath(path);
+								},
+								children: [(0, react_jsx_runtime.jsx)("input", {
+									type: "checkbox",
+									checked: true,
+									readOnly: true
+								}), (0, react_jsx_runtime.jsx)("span", { children: labelOf(path) }), (0, react_jsx_runtime.jsx)("span", {
+									className: c.wsPath,
+									title: path,
+									children: path
+								})]
+							})]
+						}, path)))
+					}) : null, mode === "scoped" ? (0, react_jsx_runtime.jsxs)("div", {
+						className: c.manualRow,
+						children: [(0, react_jsx_runtime.jsx)("input", {
+							className: c.manualInput,
+							type: "text",
+							value: manual,
+							placeholder: t("scopeManualPlaceholder"),
+							onChange: (event) => {
+								setManual(event.currentTarget.value);
+							},
+							onKeyDown: (event) => {
+								if (event.key === "Enter") {
+									event.preventDefault();
+									addManual();
+								}
+							}
+						}), (0, react_jsx_runtime.jsx)("button", {
+							type: "button",
+							className: c.manualAdd,
+							onClick: addManual,
+							children: t("scopeManualAdd")
+						})]
+					}) : null, mode === "scoped" && selected.length === 0 ? (0, react_jsx_runtime.jsx)("p", {
+						className: c.scopeWarning,
+						children: t("scopeZeroWarning")
+					}) : null, (0, react_jsx_runtime.jsxs)("div", {
+						className: c.scopeActions,
+						children: [(0, react_jsx_runtime.jsx)("button", {
+							type: "button",
+							className: c.scopeAction + " " + c.scopeCancel,
+							disabled: busy,
+							onClick: onCancel,
+							children: t("scopeCancel")
+						}), (0, react_jsx_runtime.jsx)("button", {
+							type: "button",
+							className: c.scopeAction + " " + c.scopeConfirm,
+							disabled: busy || (mode === "scoped" && selected.length === 0),
+							onClick: submit,
+							children: busy ? t("scopeSaving") : initial !== null && initial !== undefined ? t("scopeSave") : t("scopeConfirm")
+						})]
+					})]
+				})
+			});
+		}
+
 		function SkillsSection(props) {
-			const { t, currentSessionId, listSkills, loadContent, setSkillEnabled, removeSkill, addSkill } = props;
+			const { t, currentSessionId, listSkills, loadContent, setSkillEnabled, removeSkill, addSkill, listWorkspaces, setSkillScope } = props;
 			const [query, setQuery] = react.useState("");
 			const [listState, setListState] = react.useState({ status: "loading" });
 			const [request, setRequest] = react.useState(0);
@@ -221,6 +443,10 @@ window.__ModuleLoader__.load({
 			const [ops, setOps] = react.useState({});
 			const [adding, setAdding] = react.useState({ status: "idle" });
 			const [addMenuOpen, setAddMenuOpen] = react.useState(false);
+			const [pendingAdd, setPendingAdd] = react.useState(null);
+			const [scopeEditor, setScopeEditor] = react.useState(null);
+			const [scopeBusy, setScopeBusy] = react.useState(false);
+			const [wsOptions, setWsOptions] = react.useState(null);
 			const inflight = react.useRef(new Set());
 			const folderInput = react.useRef(null);
 			const fileInput = react.useRef(null);
@@ -313,12 +539,62 @@ window.__ModuleLoader__.load({
 				setAdding({ status: "busy" });
 				Promise.all(files.map(readFileAsBase64)).then((items) => {
 					const payloadFiles = items.map((base64, index) => ({ path: (files[index].webkitRelativePath || files[index].name).replaceAll("\\", "/"), base64 }));
-					return addSkill({ kind, files: payloadFiles });
-				}).then(() => {
+					if (wsOptions === null) {
+						Promise.resolve().then(() => listWorkspaces()).then((snapshot) => {
+							const list = snapshot !== null && typeof snapshot === "object" && Array.isArray(snapshot.workspaces) ? snapshot.workspaces : [];
+							setWsOptions(list);
+							setPendingAdd({ kind, payloadFiles });
+						}, () => {
+							setWsOptions([]);
+							setPendingAdd({ kind, payloadFiles });
+						});
+					} else {
+						setPendingAdd({ kind, payloadFiles });
+					}
+				}, (error) => {
+					setAdding({ status: "error", message: cleanHostError(error) });
+				});
+			};
+
+			// 作用域选择完成后真正上传。
+			const submitPendingAdd = (workspaces) => {
+				const payload = pendingAdd;
+				setPendingAdd(null);
+				setAdding({ status: "busy" });
+				Promise.resolve().then(() => addSkill({ kind: payload.kind, files: payload.payloadFiles, workspaces })).then(() => {
 					setAdding({ status: "ok" });
 					setTimeout(() => setRequest((value) => value + 1), 700);
 					setTimeout(() => setAdding({ status: "idle" }), 2500);
 				}, (error) => {
+					setAdding({ status: "error", message: cleanHostError(error) });
+				});
+			};
+
+			// 编辑作用域：打开弹层并预载工作区选项。
+			const openScopeEditor = (skill) => {
+				setScopeBusy(false);
+				setScopeEditor({ name: skill.name, scope: skill.scope ?? null });
+				if (wsOptions === null) {
+					Promise.resolve().then(() => listWorkspaces()).then((snapshot) => {
+						const list = snapshot !== null && typeof snapshot === "object" && Array.isArray(snapshot.workspaces) ? snapshot.workspaces : [];
+						setWsOptions(list);
+					}, () => {
+						setWsOptions([]);
+					});
+				}
+			};
+
+			const applySetScope = (name, workspaces) => {
+				setScopeBusy(true);
+				setOps((prev) => ({ ...prev, [name]: { status: "busy" } }));
+				Promise.resolve().then(() => setSkillScope(name, workspaces)).then(() => {
+					setScopeBusy(false);
+					setScopeEditor(null);
+					setOps((prev) => ({ ...prev, [name]: { status: "ok" } }));
+					reloadAfterHot();
+				}, (error) => {
+					setScopeBusy(false);
+					setOps((prev) => ({ ...prev, [name]: { status: "error" } }));
 					setAdding({ status: "error", message: cleanHostError(error) });
 				});
 			};
@@ -357,6 +633,20 @@ window.__ModuleLoader__.load({
 			const normalizedQuery = query.trim().toLocaleLowerCase();
 			const skills = listState.status === "ready" ? listState.skills : [];
 			const filtered = skills.filter((skill) => skill.name.toLocaleLowerCase().includes(normalizedQuery));
+
+			// 作用域标签文案。
+			const scopeInfo = (skill) => {
+				const scope = skill.scope;
+				if (scope === undefined || scope === null) return null;
+				if (scope.kind === "global") return { text: t("scopeGlobal"), scoped: false, zero: false, title: t("scopeGlobalOption") };
+				const workspaces = Array.isArray(scope.workspaces) ? scope.workspaces : [];
+				return {
+					text: t("scopeScopedPrefix") + workspaces.length + t("scopeScopedSuffix"),
+					scoped: true,
+					zero: workspaces.length === 0,
+					title: workspaces.map((workspace) => workspace.path).join("\n")
+				};
+			};
 
 			// 搜索过滤掉已展开项时自动收起。
 			react.useEffect(() => {
@@ -512,6 +802,7 @@ window.__ModuleLoader__.load({
 								const enabled = skill.enabled !== false;
 								const editable = skill.source !== "bundled" && skill.source !== "runtime";
 								const op = ops[skill.name];
+								const scope = scopeInfo(skill);
 								return (0, react_jsx_runtime.jsxs)("li", {
 									key: skill.name,
 									className: c.card,
@@ -542,7 +833,13 @@ window.__ModuleLoader__.load({
 												className: c.configTag,
 												"data-enabled": enabled ? "true" : "false",
 												children: enabled ? t("enabledTag") : t("disabledTag")
-											}), (0, react_jsx_runtime.jsx)(primitives.IconChevronDownOutline14, {
+											}), scope !== null ? (0, react_jsx_runtime.jsx)("span", {
+												className: c.scopeTag,
+												"data-scoped": scope.scoped ? "true" : "false",
+												"data-zero": scope.zero ? "true" : "false",
+												title: scope.title,
+												children: scope.text
+											}) : null, (0, react_jsx_runtime.jsx)(primitives.IconChevronDownOutline14, {
 												className: c.chevron,
 												size: 12,
 												"aria-hidden": "true"
@@ -600,6 +897,14 @@ window.__ModuleLoader__.load({
 											}), op?.status === "error" ? (0, react_jsx_runtime.jsx)("span", {
 												className: c.opError,
 												children: t("opFailed")
+											}) : null, skill.scope !== undefined ? (0, react_jsx_runtime.jsx)("button", {
+												type: "button",
+												className: c.scopeEditButton,
+												disabled: op?.status === "busy",
+												onClick: () => {
+													openScopeEditor(skill);
+												},
+												children: t("scopeEditLabel")
 											}) : null, (0, react_jsx_runtime.jsx)("button", {
 												type: "button",
 												className: c.deleteButton,
@@ -627,7 +932,29 @@ window.__ModuleLoader__.load({
 							type: "file",
 							accept: ".md,text/markdown",
 							onChange: onPickFile
-						})
+						}),
+						pendingAdd !== null ? (0, react_jsx_runtime.jsx)(ScopeDialog, {
+							t,
+							options: wsOptions,
+							initial: null,
+							busy: false,
+							onCancel: () => {
+								setPendingAdd(null);
+							},
+							onConfirm: submitPendingAdd
+						}) : null,
+						scopeEditor !== null ? (0, react_jsx_runtime.jsx)(ScopeDialog, {
+							t,
+							options: wsOptions,
+							initial: scopeEditor.scope,
+							busy: scopeBusy,
+							onCancel: () => {
+								setScopeEditor(null);
+							},
+							onConfirm: (workspaces) => {
+								applySetScope(scopeEditor.name, workspaces);
+							}
+						}) : null
 					]
 				})
 			});
@@ -692,8 +1019,10 @@ window.__ModuleLoader__.load({
 			const sectionFace = () => ({
 				currentSessionId,
 				listSkills: () => callRemote("list", currentSessionId()),
+				listWorkspaces: () => callRemote("workspaces"),
 				loadContent: (name) => callRemote("content", name, currentSessionId()),
 				setSkillEnabled: (name, enabled) => callRemote("setEnabled", name, currentSessionId(), enabled),
+				setSkillScope: (name, workspaces) => callRemote("setScope", name, currentSessionId(), workspaces),
 				removeSkill: (name) => callRemote("deleteSkill", name, currentSessionId()),
 				addSkill: (payload) => callRemote("addSkill", currentSessionId(), payload)
 			});

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,10 +8,26 @@ import {
   DISABLED_SUFFIX,
   buildRoots,
   collectSkillEntries,
+  findProjectRoot,
+  parseFrontmatter,
   pathExists,
   validateFrontmatter,
   winnerEntry
 } from "./skill-files.js";
+import {
+  deleteScopedSkill,
+  ensureJunction,
+  loadBindings,
+  normalizeWorkspaces,
+  pruneStaleWorkspaces,
+  scopeSkill,
+  scopedContent,
+  scopedEnabled,
+  setScopedEnabled,
+  storeRoot,
+  storeSkillDir,
+  workspaceLink
+} from "./scope.js";
 
 /**
  * dsh-skill-viewer - host half.
@@ -20,6 +36,14 @@ import {
  * skill catalog (enabled + hot-disabled) and hot management operations:
  * enable/disable (rename to/from *.disabled), delete, and add (import a
  * skill bundle or flat markdown file into the user skills root).
+ *
+ * Since the workspace-scope extension, skills may also be scoped to one or
+ * more workspaces: the file lives once in the managed store
+ * (~/.dsh/skills/.system/skill-viewer) and each bound workspace's project
+ * root carries a junction, so the skill is discoverable only for sessions
+ * inside those workspaces. Workspace deletion removes the junction with the
+ * workspace and stale bindings are pruned automatically; the stored skill
+ * itself is never lost.
  *
  * The skill-filesystem provider's file watcher picks every change up within
  * ~200ms, so none of these operations require a gateway restart.
@@ -31,6 +55,17 @@ export const inject = ["typert", "skills", "sessions", "agents"];
 
 const sessionIdSchema = z.string().optional();
 
+const scopeWorkspaceSchema = z.object({
+  path: z.string(),
+  label: z.string(),
+  exists: z.boolean()
+});
+
+const scopeSchema = z.object({
+  kind: z.enum(["global", "workspaces"]),
+  workspaces: z.array(scopeWorkspaceSchema).optional()
+});
+
 const skillSummarySchema = z.object({
   name: z.string(),
   description: z.string(),
@@ -39,10 +74,15 @@ const skillSummarySchema = z.object({
   source: z.string(),
   enabled: z.boolean(),
   modelInvocable: z.boolean(),
-  userInvocable: z.boolean()
+  userInvocable: z.boolean(),
+  scope: scopeSchema.optional()
 });
 
 const listResultSchema = z.object({ skills: z.array(skillSummarySchema) });
+
+const workspacesResultSchema = z.object({
+  workspaces: z.array(z.object({ path: z.string(), label: z.string(), sessions: z.number() }))
+});
 
 const resourceBaseSchema = z
   .object({
@@ -67,11 +107,17 @@ const skillContentSchema = z
 
 const setEnabledResultSchema = z.object({ name: z.string(), enabled: z.boolean() });
 
+const setScopeResultSchema = z.object({ name: z.string(), scope: scopeSchema });
+
 const deleteSkillResultSchema = z.object({ name: z.string() });
 
 const addFileSchema = z.object({ path: z.string(), base64: z.string() });
-const addPayloadSchema = z.object({ kind: z.enum(["bundle", "flat"]), files: z.array(addFileSchema).min(1) });
-const addResultSchema = z.object({ name: z.string(), kind: z.enum(["bundle", "flat"]) });
+const addPayloadSchema = z.object({
+  kind: z.enum(["bundle", "flat"]),
+  files: z.array(addFileSchema).min(1),
+  workspaces: z.array(z.string()).nullable().optional()
+});
+const addResultSchema = z.object({ name: z.string(), kind: z.enum(["bundle", "flat"]), scope: scopeSchema });
 
 /** Typed wire descriptors registered with the API gateway. */
 const MANIFEST = {
@@ -89,6 +135,15 @@ const MANIFEST = {
         { name: "sessionId", wire: "sessionId", source: "json", acceptsUndefined: true, codec: { mode: "strict", typeSymbol: "dsh-skill-viewer#sessionId", schema: sessionIdSchema } }
       ],
       result: { mode: "strict", typeSymbol: "dsh-skill-viewer#SkillListResult", schema: listResultSchema }
+    },
+    {
+      id: "dsh-skill-viewer#skillsViewer/workspaces",
+      service: "skillsViewer",
+      namespace: "skillsViewer",
+      method: "workspaces",
+      invocation: { kind: "direct" },
+      parameters: [],
+      result: { mode: "strict", typeSymbol: "dsh-skill-viewer#WorkspacesResult", schema: workspacesResultSchema }
     },
     {
       id: "dsh-skill-viewer#skillsViewer/content",
@@ -114,6 +169,19 @@ const MANIFEST = {
         { name: "enabled", wire: "enabled", source: "json", codec: { mode: "strict", typeSymbol: "dsh-skill-viewer#EnabledFlag", schema: z.boolean() } }
       ],
       result: { mode: "strict", typeSymbol: "dsh-skill-viewer#SetEnabledResult", schema: setEnabledResultSchema }
+    },
+    {
+      id: "dsh-skill-viewer#skillsViewer/setScope",
+      service: "skillsViewer",
+      namespace: "skillsViewer",
+      method: "setScope",
+      invocation: { kind: "direct" },
+      parameters: [
+        { name: "name", wire: "name", source: "json", codec: { mode: "strict", typeSymbol: "dsh-skill-viewer#SkillName", schema: z.string() } },
+        { name: "sessionId", wire: "sessionId", source: "json", acceptsUndefined: true, codec: { mode: "strict", typeSymbol: "dsh-skill-viewer#sessionId", schema: sessionIdSchema } },
+        { name: "workspaces", wire: "workspaces", source: "json", codec: { mode: "strict", typeSymbol: "dsh-skill-viewer#WorkspaceList", schema: z.array(z.string()).nullable() } }
+      ],
+      result: { mode: "strict", typeSymbol: "dsh-skill-viewer#SetScopeResult", schema: setScopeResultSchema }
     },
     {
       id: "dsh-skill-viewer#skillsViewer/deleteSkill",
@@ -188,26 +256,70 @@ class SkillsViewerGateway extends TypertRemoteService {
     return collectSkillEntries(await this.rootsFor(sessionId));
   }
 
+  /** The managed bindings map, pruned of stale workspaces, plus the dsh home. */
+  async managedState() {
+    const dshHome = resolveDshHome();
+    const bindings = await loadBindings(dshHome);
+    await pruneStaleWorkspaces(dshHome, bindings);
+    return { dshHome, bindings };
+  }
+
+  /** The scope wire shape for one managed binding. */
+  async scopeFor(dshHome, binding) {
+    const name = binding?.name ?? "";
+    const workspaces = Array.isArray(binding?.workspaces) ? binding.workspaces : undefined;
+    if (workspaces === undefined) return { kind: "global" };
+    if (workspaces.length === 0) return { kind: "workspaces", workspaces: [] };
+    const rows = [];
+    for (const workspace of workspaces) {
+      rows.push({
+        path: workspace,
+        label: basename(workspace) || workspace,
+        exists: (name !== "" && (await pathExists(workspaceLink(workspace, name)))) || await pathExists(workspace)
+      });
+    }
+    return { kind: "workspaces", workspaces: rows };
+  }
+
+  /** Whether a skill row is scope-manageable (lives in the user root or store). */
+  isScopable(binding, source) {
+    return binding !== undefined || source === "user-dsh";
+  }
+
+  /** The scope field for a skill row, or an empty object when not manageable. */
+  async scopeField(dshHome, binding, name, source) {
+    if (!this.isScopable(binding, source)) return {};
+    return { scope: (await this.scopeFor(dshHome, binding === undefined ? undefined : { ...binding, name })) ?? { kind: "global" } };
+  }
+
   // ── remote methods ─────────────────────────────────────────────────────────
 
-  /** The merged catalog: live registry skills + hot-disabled file entries. */
+  /** The merged catalog: live registry skills + managed scoped skills. */
   async list(sessionId) {
     const { registry, cwd, scope } = this.viewFor(sessionId);
+    const { dshHome, bindings } = await this.managedState();
     const listed = await registry.list({ cwd, scope });
-    const skills = listed.map((skill) => ({
-      name: skill.name,
-      description: skill.description,
-      ...(skill.whenToUse === undefined ? {} : { whenToUse: skill.whenToUse }),
-      provider: skill.provider,
-      source: skill.source ?? (skill.provider === "runtime" ? "runtime" : ""),
-      enabled: true,
-      modelInvocable: skill.invocation.modelInvocable,
-      userInvocable: skill.invocation.userInvocable
-    }));
+    const skills = [];
+    for (const skill of listed) {
+      const binding = bindings[skill.name];
+      const source = skill.source ?? (skill.provider === "runtime" ? "runtime" : "");
+      skills.push({
+        name: skill.name,
+        description: skill.description,
+        ...(skill.whenToUse === undefined ? {} : { whenToUse: skill.whenToUse }),
+        provider: skill.provider,
+        source,
+        enabled: true,
+        modelInvocable: skill.invocation.modelInvocable,
+        userInvocable: skill.invocation.userInvocable,
+        ...(await this.scopeField(dshHome, binding, skill.name, source))
+      });
+    }
     const seen = new Set(skills.map((skill) => skill.name));
     for (const entry of await this.fileEntries(sessionId)) {
       if (entry.enabled || seen.has(entry.name)) continue;
       seen.add(entry.name);
+      const binding = bindings[entry.name];
       skills.push({
         name: entry.name,
         description: entry.description,
@@ -215,26 +327,110 @@ class SkillsViewerGateway extends TypertRemoteService {
         source: entry.source,
         enabled: false,
         modelInvocable: false,
-        userInvocable: false
+        userInvocable: false,
+        ...(await this.scopeField(dshHome, binding, entry.name, entry.source))
+      });
+    }
+    // Scoped skills bound only to OTHER workspaces stay manageable here:
+    // overlay them from the store so the user can see, toggle, re-scope or
+    // delete them from any session.
+    for (const [name, binding] of Object.entries(bindings)) {
+      if (seen.has(name)) continue;
+      if (binding === undefined || binding.workspaces === undefined) continue;
+      const raw = await scopedContent(dshHome, name);
+      const parsed = raw === undefined ? undefined : parseFrontmatter(raw);
+      skills.push({
+        name,
+        description: parsed?.description ?? "",
+        ...(parsed?.whenToUse === undefined ? {} : { whenToUse: parsed.whenToUse }),
+        provider: "filesystem",
+        source: "user-dsh",
+        enabled: await scopedEnabled(dshHome, name),
+        modelInvocable: false,
+        userInvocable: false,
+        scope: await this.scopeFor(dshHome, { ...binding, name })
       });
     }
     return { skills };
   }
 
-  /** Locate a skill: live in the registry, disabled on disk, or missing. */
+  /** Distinct project roots of all known workspaces (for the scope picker). */
+  async workspaces() {
+    const map = new Map();
+    const keyOf = (path) => process.platform === "win32" ? path.toLowerCase() : path;
+    const add = async (path, label, sessions) => {
+      if (typeof path !== "string" || path === "") return;
+      let project;
+      try {
+        project = await findProjectRoot(resolvePath(path));
+      } catch {
+        return;
+      }
+      const key = keyOf(project);
+      if (map.has(key)) return;
+      map.set(key, { path: project, label: label || basename(project) || project, sessions: sessions ?? 0 });
+    };
+    // Primary source: the durable workspace registry (every historical
+    // workspace, not just sessions currently loaded in memory).
+    try {
+      const registry = this.ctx.get("workspaceRegistry");
+      if (registry !== undefined && typeof registry.list === "function") {
+        for (const workspace of registry.list()) {
+          try {
+            // status() is ASYNC: comparing the promise directly would skip
+            // every workspace.
+            if ((await workspace.status()) !== "ok") continue;
+          } catch {
+            // status probe unavailable: keep the record
+          }
+          await add(workspace.path, workspace.title, Array.isArray(workspace.sessionIds) ? workspace.sessionIds.length : 0);
+        }
+      }
+    } catch {
+      // registry unavailable: fall back to live sessions below
+    }
+    // Supplement: live sessions whose cwd is not yet a registered workspace.
+    try {
+      for (const session of this.ctx.sessions.list()) {
+        const cwd = session.header?.cwd;
+        if (cwd === undefined || cwd === "") continue;
+        await add(resolvePath(cwd), undefined, 1);
+      }
+    } catch {
+      // session listing unavailable: empty picker
+    }
+    return { workspaces: [...map.values()].sort((a, b) => a.label.localeCompare(b.label) || a.path.localeCompare(b.path)) };
+  }
+
+  /** Locate a skill: live in the registry, managed scoped, disabled on disk, or missing. */
   async locate(name, sessionId) {
     const { registry, cwd, scope } = this.viewFor(sessionId);
     const skill = await registry.get(name, { cwd, scope });
     if (skill !== undefined) return { kind: "live", skill };
+    const { dshHome, bindings } = await this.managedState();
+    const binding = bindings[name];
+    if (binding !== undefined && binding.workspaces !== undefined) return { kind: "scoped", dshHome, binding };
     const entry = winnerEntry(await this.fileEntries(sessionId), name);
     if (entry !== undefined && !entry.enabled) return { kind: "disabled", entry };
     return { kind: "missing" };
   }
 
-  /** Full body: the registry definition, or the disabled file when present. */
+  /** Full body: the registry definition, the scoped store, or the disabled file. */
   async content(name, sessionId) {
     const located = await this.locate(name, sessionId);
     if (located.kind === "missing") return null;
+    if (located.kind === "scoped") {
+      const raw = await scopedContent(located.dshHome, name);
+      const parsed = raw === undefined ? undefined : parseFrontmatter(raw);
+      return {
+        name,
+        description: parsed?.description ?? "",
+        content: raw ?? "",
+        provider: "filesystem",
+        path: join(storeSkillDir(located.dshHome, name), "SKILL.md"),
+        ...(parsed?.whenToUse === undefined ? {} : { whenToUse: parsed.whenToUse })
+      };
+    }
     if (located.kind === "disabled") {
       const raw = await readFile(located.entry.file, "utf8");
       return {
@@ -264,6 +460,12 @@ class SkillsViewerGateway extends TypertRemoteService {
 
   /** Hot enable/disable: rename the skill file to/from *.disabled. */
   async setEnabled(name, sessionId, enabled) {
+    const { dshHome, bindings } = await this.managedState();
+    const binding = bindings[name];
+    if (binding !== undefined && binding.workspaces !== undefined) {
+      const changed = await setScopedEnabled(dshHome, name, enabled);
+      return { name, enabled: changed ? enabled : !enabled };
+    }
     const located = await this.locate(name, sessionId);
     if (located.kind === "missing") throw new Error('技能 "' + name + '" 不存在');
     if (located.kind === "live") {
@@ -281,8 +483,35 @@ class SkillsViewerGateway extends TypertRemoteService {
     return { name, enabled: true };
   }
 
-  /** Delete a skill permanently (directory bundles remove the whole dir). */
+  /**
+   * Change a managed skill's scope: global (`null`) or a workspace list.
+   * Workspaces must exist; each resolves to its nearest git-root project dir.
+   */
+  async setScope(name, sessionId, workspaces) {
+    const { dshHome, bindings } = await this.managedState();
+    const binding = bindings[name];
+    let globalLocator;
+    if (binding === undefined) {
+      // The skill is global (or external): it must live in the user skills
+      // root to be scoped. Bundled/runtime/project-local skills are refused.
+      const entry = winnerEntry(await this.fileEntries(sessionId), name);
+      if (entry === undefined || entry.source !== "user-dsh") throw new Error('技能 "' + name + '" 不在用户技能目录中，无法设置作用域');
+      globalLocator = entry;
+    }
+    await scopeSkill(dshHome, name, workspaces, globalLocator);
+    const after = await loadBindings(dshHome);
+    const next = after[name];
+    return { name, scope: await this.scopeFor(dshHome, next === undefined ? undefined : { ...next, name }) ?? { kind: "global" } };
+  }
+
+  /** Delete a skill permanently (scoped: store + junctions + binding). */
   async deleteSkill(name, sessionId) {
+    const { dshHome, bindings } = await this.managedState();
+    const binding = bindings[name];
+    if (binding !== undefined && binding.workspaces !== undefined) {
+      await deleteScopedSkill(dshHome, name);
+      return { name };
+    }
     const located = await this.locate(name, sessionId);
     if (located.kind === "missing") throw new Error('技能 "' + name + '" 不存在');
     if (located.kind === "live") {
@@ -299,15 +528,13 @@ class SkillsViewerGateway extends TypertRemoteService {
   }
 
   /**
-   * Import a new skill into the user skills root:
-   *   bundle = a directory tree whose top level contains exactly one SKILL.md
-   *   flat   = a single markdown file
-   * The frontmatter is validated before writing; afterwards the registry is
-   * polled to confirm DSH accepted the skill — otherwise the files are rolled
-   * back and the rejection is reported.
+   * Import a new skill. Without `workspaces` the skill lands in the global
+   * user root (default, unchanged behavior). With one or more workspace paths
+   * it lands in the managed store and each workspace's project root receives
+   * a junction; DSH then discovers it only for those workspaces.
    */
   async addSkill(sessionId, payload) {
-    const { kind, files } = payload;
+    const { kind, files, workspaces: rawWorkspaces } = payload;
     if (files.length > MAX_ADD_FILES) throw new Error("文件数量过多（最多 " + MAX_ADD_FILES + " 个）");
     const decoded = files.map((file) => {
       const data = Buffer.from(file.base64, "base64");
@@ -323,6 +550,9 @@ class SkillsViewerGateway extends TypertRemoteService {
 
     const dshHome = resolveDshHome();
     const userRoot = join(dshHome, "skills");
+    const scoped = rawWorkspaces !== undefined && rawWorkspaces !== null && rawWorkspaces.length > 0;
+    const workspaces = scoped ? await normalizeWorkspaces(rawWorkspaces) : null;
+    if (scoped && workspaces.length === 0) throw new Error("至少需要指定一个存在的工作区");
 
     // Determine the canonical skill name and the files to write.
     let name;
@@ -348,34 +578,96 @@ class SkillsViewerGateway extends TypertRemoteService {
       writes = [{ relative: flatName, data: file.data }];
     }
 
-    // Refuse duplicates: the name may not exist enabled or disabled.
+    // Refuse duplicates: the name may not exist enabled, disabled, or scoped.
+    const { bindings } = await this.managedState();
+    if (bindings[name] !== undefined) throw new Error('同名技能 "' + name + '" 已存在（工作区限定）');
     const existing = winnerEntry(await this.fileEntries(sessionId), name);
     if (existing !== undefined) throw new Error('同名技能 "' + name + '" 已存在（' + (existing.enabled ? "已启用" : "已停用") + "）");
     const { registry, cwd, scope } = this.viewFor(sessionId);
     if ((await registry.list({ cwd, scope })).some((skill) => skill.name === name)) throw new Error('同名技能 "' + name + '" 已存在');
 
-    // Write the files (the gateway's watcher will discover them).
-    const target = kind === "bundle" ? join(userRoot, name) : join(userRoot, writes[0].relative);
+    if (!scoped) {
+      // Global: the original flow — write into the user skills root.
+      const target = kind === "bundle" ? join(userRoot, name) : join(userRoot, writes[0].relative);
+      try {
+        for (const write of writes) {
+          const filePath = kind === "bundle" ? join(target, write.relative) : target;
+          await mkdir(dirname(filePath), { recursive: true });
+          await writeFile(filePath, write.data);
+        }
+      } catch (error) {
+        await rm(target, { recursive: true, force: true }).catch(() => {});
+        throw new Error("写入技能文件失败：" + (error instanceof Error ? error.message : String(error)));
+      }
+      const accepted = await this.waitForDiscovery(name, sessionId);
+      if (!accepted) {
+        await rm(target, { recursive: true, force: true }).catch(() => {});
+        throw new Error("DSH 未接受该技能（格式校验未通过），已回滚。请检查 frontmatter 后重试");
+      }
+      return { name, kind, scope: { kind: "global" } };
+    }
+
+    // Scoped: store once, link into each workspace, record the binding.
+    // Flat uploads become a bundle layout (<name>/SKILL.md) in the store
+    // because that is the only layout the provider discovers through a
+    // junction; the original file name is kept for un-scoping later.
+    const storeDir = storeSkillDir(dshHome, name);
+    const scopedWrites = scoped && kind === "flat" ? [{ relative: "SKILL.md", data: writes[0].data }] : writes;
+    const created = [];
     try {
-      for (const write of writes) {
-        const filePath = kind === "bundle" ? join(target, write.relative) : target;
+      await mkdir(storeRoot(dshHome), { recursive: true });
+      for (const write of scopedWrites) {
+        const filePath = join(storeDir, write.relative);
         await mkdir(dirname(filePath), { recursive: true });
         await writeFile(filePath, write.data);
       }
+      for (const workspace of workspaces) {
+        await ensureJunction(storeDir, workspaceLink(workspace, name));
+        created.push(workspace);
+      }
     } catch (error) {
-      await rm(target, { recursive: true, force: true }).catch(() => {});
-      throw new Error("写入技能文件失败：" + (error instanceof Error ? error.message : String(error)));
+      for (const workspace of created) await (async () => {
+        try {
+          await rm(workspaceLink(workspace, name), { recursive: true, force: true });
+        } catch {}
+      })();
+      await rm(storeDir, { recursive: true, force: true }).catch(() => {});
+      throw new Error("写入技能文件失败（已回滚）：" + (error instanceof Error ? error.message : String(error)));
     }
 
-    // Let DSH itself be the final judge: poll the registry until the skill
-    // shows up (the watcher needs a moment to invalidate caches). Roll back
-    // when it never does.
-    const accepted = await this.waitForDiscovery(name, sessionId);
-    if (!accepted) {
-      await rm(target, { recursive: true, force: true }).catch(() => {});
-      throw new Error("DSH 未接受该技能（格式校验未通过），已回滚。请检查 frontmatter 后重试");
+    // Persist the binding; roll the layout back if the manifest cannot save.
+    const afterBindings = await loadBindings(dshHome);
+    afterBindings[name] = {
+      kind: kind === "bundle" ? "bundle" : "flat",
+      workspaces,
+      ...(kind === "flat" && writes.length === 1 ? { fileName: writes[0].relative } : {})
+    };
+    try {
+      const manifestDir = storeRoot(dshHome);
+      const tmp = join(manifestDir, "bindings.json.tmp-" + process.pid);
+      await mkdir(manifestDir, { recursive: true });
+      await writeFile(tmp, JSON.stringify({ version: 1, skills: afterBindings }, void 0, 2) + "\n", "utf8");
+      await rename(tmp, join(manifestDir, "bindings.json"));
+    } catch (error) {
+      for (const workspace of created) await (async () => {
+        try {
+          await rm(workspaceLink(workspace, name), { recursive: true, force: true });
+        } catch {}
+      })();
+      await rm(storeDir, { recursive: true, force: true }).catch(() => {});
+      throw new Error("保存绑定失败（已回滚）：" + (error instanceof Error ? error.message : String(error)));
     }
-    return { name, kind };
+
+    // Let DSH itself be the final judge against the first bound workspace.
+    const discovery = await this.waitForScopedDiscovery(name, workspaces[0], sessionId);
+    if (!discovery.ok) {
+      await deleteScopedSkill(dshHome, name);
+      const detail = discovery.linkOk
+        ? "联接点已创建，但 DSH 的技能发现器未列出该技能（通常是 frontmatter 被 DSH 的 YAML 解析器拒绝；该工作区当前可见的技能：" + (discovery.names.join("、") || "无") + "）"
+        : "工作区联接点丢失：" + workspaceLink(workspaces[0], name);
+      throw new Error('DSH 未能在工作区 "' + workspaces[0] + '" 中发现该技能，已回滚。' + detail + "。请检查 SKILL.md 的 frontmatter 后重试");
+    }
+    return { name, kind, scope: { kind: "workspaces", workspaces: workspaces.map((path) => ({ path, label: basename(path) || path, exists: true })) } };
   }
 
   async waitForDiscovery(name, sessionId) {
@@ -390,6 +682,37 @@ class SkillsViewerGateway extends TypertRemoteService {
       }
     }
     return false;
+  }
+
+  async waitForScopedDiscovery(name, workspace, sessionId) {
+    // Use the SAME view sessions read: in the web profile the host-level
+    // skill-filesystem row is disabled and the filesystem provider registers
+    // into the agent preset's SCOPE LAYER of the shared registry — reachable
+    // only when the session's agent is passed as `scope` (which is exactly
+    // what the UI's own list() does; a scope-less host query sees no provider).
+    const { registry, scope } = this.viewFor(sessionId);
+    // The provider may need a beat to attach its watcher to a freshly created
+    // workspace `.dsh/skills` root, so poll a generous window before giving up.
+    for (let attempt = 0; attempt < 12; attempt++) {
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 500));
+      try {
+        if ((await registry.get(name, { cwd: workspace, scope })) !== undefined) return { ok: true };
+      } catch {
+        // registry unavailable: treat as accepted (nothing to verify against)
+        return { ok: true };
+      }
+    }
+    // Diagnose the miss so the user gets an actionable message instead of a
+    // generic rollback: is the junction still there, and what DOES the
+    // registry list for that workspace right now?
+    let names = [];
+    try {
+      names = (await registry.list({ cwd: workspace, scope })).map((skill) => skill.name);
+    } catch {
+      // diagnostic only
+    }
+    const linkOk = await pathExists(workspaceLink(workspace, name));
+    return { ok: false, names, linkOk };
   }
 }
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1,0 +1,445 @@
+/**
+ * dsh-skill-viewer — workspace-scoped skill layout engine.
+ *
+ * Single source of truth for how a skill can be scoped to one or more
+ * workspaces while still living in the global user skills root:
+ *
+ *   - global (default):   <dshHome>/skills/<name>/SKILL.md   (unchanged)
+ *   - scoped:             <dshHome>/skills/.system/skill-viewer/<name>/SKILL.md
+ *                         + one junction per workspace:
+ *                           <workspaceProjectRoot>/.dsh/skills/<name> -> store dir
+ *
+ * Why this works with @deepseek-ai/dsh-skill-filesystem:
+ *   - the user-dsh root skips its `.system` child, so the store is invisible
+ *     to discovery (and its watcher ignores events below `.system`);
+ *   - project roots are discovered per session cwd, so a junction inside a
+ *     workspace's `.dsh/skills` makes the skill visible ONLY for sessions
+ *     whose project root is that workspace;
+ *   - discovery follows directory symlinks/junctions (the filesystem service
+ *     classifies entries by `stat`, which resolves the reparse point), so the
+ *     single stored copy is read through every link.
+ *
+ * Bindings live in <store>/bindings.json:
+ *   { "version": 1, "skills": { "<name>": {
+ *       "kind": "bundle" | "flat",        // original layout in the user root
+ *       "fileName": string | undefined,   // original flat file name (for restore)
+ *       "workspaces": string[]            // project-root paths; scoped only
+ *   } } }
+ *
+ * Global skills carry no binding entry at all — the default state.
+ * This module is dependency-free (node:fs / node:path / node:os only).
+ */
+import { access, cp, lstat, mkdir, readFile, readlink, rename, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { basename, dirname, join, resolve } from "node:path";
+import { findProjectRoot } from "./skill-files.js";
+
+/** Binding payload version this engine writes. */
+export const BINDINGS_VERSION = 1;
+
+/** File name of the bindings manifest inside the managed store. */
+export const BINDINGS_FILENAME = "bindings.json";
+
+/** Marker suffix for a hot-disabled skill file (mirrors the provider convention). */
+export const DISABLED_SUFFIX = ".disabled";
+
+/** The managed store root: <dshHome>/skills/.system/skill-viewer. */
+export function storeRoot(dshHome) {
+  return join(dshHome, "skills", ".system", "skill-viewer");
+}
+
+/** The bindings manifest path. */
+export function bindingsFile(dshHome) {
+  return join(storeRoot(dshHome), BINDINGS_FILENAME);
+}
+
+/** The stored bundle directory for one scoped skill. */
+export function storeSkillDir(dshHome, name) {
+  return join(storeRoot(dshHome), name);
+}
+
+/** The bundle directory for one global skill in the user root. */
+export function userBundleDir(dshHome, name) {
+  return join(dshHome, "skills", name);
+}
+
+/** The junction a scoped skill gets inside one workspace's project root. */
+export function workspaceLink(workspace, name) {
+  return join(workspace, ".dsh", "skills", name);
+}
+
+/** True when any filesystem entry exists at the path (follows links). */
+export async function pathExists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** True when the path itself is a symlink/junction (lstat semantics). */
+export async function isJunction(path) {
+  try {
+    const info = await lstat(path);
+    return info.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+/** Whether a directory path exists and is a directory (follows links). */
+export async function isDirectory(path) {
+  try {
+    const info = await stat(path);
+    return info.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Normalize a list of raw workspace paths into distinct project-root paths.
+ * Every path must exist; each resolves to its nearest `.git` ancestor (or
+ * itself when there is none) because that is where the skill provider looks
+ * for `<projectRoot>/.dsh/skills`. Case-insensitive dedupe on Windows.
+ * @param paths - raw workspace paths from the UI/CLI.
+ * @returns distinct absolute project-root paths, in input order.
+ */
+export async function normalizeWorkspaces(paths) {
+  const seen = new Set();
+  const result = [];
+  for (const raw of paths) {
+    if (typeof raw !== "string" || raw.trim() === "") continue;
+    const absolute = resolve(raw.trim());
+    if (!(await isDirectory(absolute))) throw new Error('工作区不存在或不是目录："' + raw + '"');
+    const project = await findProjectRoot(absolute);
+    const key = process.platform === "win32" ? project.toLowerCase() : project;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(project);
+  }
+  return result;
+}
+
+/** Read the bindings manifest; a missing or malformed file is empty state. */
+export async function loadBindings(dshHome) {
+  try {
+    const parsed = JSON.parse(await readFile(bindingsFile(dshHome), "utf8"));
+    if (parsed !== null && typeof parsed === "object" && parsed.skills !== null && typeof parsed.skills === "object") return parsed.skills;
+  } catch {
+    // absent or malformed manifest: treat as empty
+  }
+  return {};
+}
+
+/** Atomically write the bindings manifest (temp file + rename). */
+export async function saveBindings(dshHome, skills) {
+  await mkdir(storeRoot(dshHome), { recursive: true });
+  const target = bindingsFile(dshHome);
+  const tmp = `${target}.tmp-${process.pid}`;
+  await writeFile(tmp, JSON.stringify({ version: BINDINGS_VERSION, skills }, void 0, 2) + "\n", "utf8");
+  await rename(tmp, target);
+}
+
+/**
+ * Create (or re-point) a junction at `link` towards the directory `target`.
+ * Replaces an existing junction whose target differs; a real directory or
+ * file at the link path is an error and is never removed.
+ * @returns true when the link was created or re-pointed.
+ */
+export async function ensureJunction(target, link) {
+  await mkdir(dirname(link), { recursive: true });
+  if (await isJunction(link)) {
+    const current = resolve(dirname(link), await readlink(link));
+    if (current === resolve(target)) return false;
+    await rm(link, { recursive: true, force: true });
+  } else if (await pathExists(link)) {
+    throw new Error("目标路径已存在且不是联接点：" + link);
+  }
+  await symlink(target, link, "junction");
+  return true;
+}
+
+/**
+ * Remove a junction at `link`. Real directories are never touched.
+ * @returns true when a junction was removed.
+ */
+export async function removeJunction(link) {
+  if (!(await isJunction(link))) return false;
+  await rm(link, { recursive: true, force: true });
+  return true;
+}
+
+/**
+ * Move a file or directory with Windows watcher-handle tolerance: try a plain
+ * rename first; when the OS reports a sharing violation (the skill provider's
+ * watcher may still hold the directory briefly), retry a few times and then
+ * fall back to copy + delete.
+ * @returns true when the source is gone and the target exists.
+ */
+export async function movePathRetry(source, target) {
+  for (let attempt = 0; attempt < 4; attempt++) {
+    try {
+      await rename(source, target);
+      return true;
+    } catch (error) {
+      if (!isBusyError(error)) throw error;
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 300 * (attempt + 1)));
+    }
+  }
+  // Copy + delete fallback: deletion of the source also retries.
+  await cp(source, target, { recursive: true });
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      await rm(source, { recursive: true, force: true });
+      return true;
+    } catch (error) {
+      if (!isBusyError(error)) throw error;
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 300 * (attempt + 1)));
+    }
+  }
+  return false;
+}
+
+/** Windows sharing-violation / permission codes that may clear after a beat. */
+function isBusyError(error) {
+  return error !== null && typeof error === "object" && ["EPERM", "EBUSY", "EACCES", "ENOTEMPTY"].includes(error.code);
+}
+
+/**
+ * Drop bindings whose workspace no longer carries the skill junction (the
+ * workspace was deleted, or its link was removed out-of-band). The stored
+ * skill itself is never deleted: a skill with zero remaining workspaces stays
+ * in the store and is reported as "无有效工作区" until re-bound or deleted.
+ * @param dshHome - harness home.
+ * @param skills - current bindings map (mutated in place).
+ * @returns names whose workspace list changed.
+ */
+export async function pruneStaleWorkspaces(dshHome, skills) {
+  const changed = [];
+  for (const [name, binding] of Object.entries(skills)) {
+    const workspaces = Array.isArray(binding?.workspaces) ? binding.workspaces : [];
+    if (workspaces.length === 0) continue;
+    const kept = [];
+    for (const workspace of workspaces) {
+      if (!(await isDirectory(workspace))) continue;
+      if (!(await isJunction(workspaceLink(workspace, name)))) continue;
+      kept.push(workspace);
+    }
+    if (kept.length !== workspaces.length) {
+      binding.workspaces = kept;
+      changed.push(name);
+    }
+  }
+  if (changed.length > 0) await saveBindings(dshHome, skills);
+  return changed;
+}
+
+/**
+ * Move one skill between the global user root and the scoped store,
+ * creating or removing workspace junctions as needed.
+ *
+ * @param dshHome - harness home.
+ * @param name - skill name (frontmatter name).
+ * @param workspaces - `null` for global; otherwise a raw path list whose
+ *   entries must exist (each resolves to its project root).
+ * @param globalLocator - when the skill is currently global and managed by
+ *   the caller's scan, `{ file, dirBundle, enabled }`; otherwise the engine
+ *   reads the binding map.
+ * @returns the updated binding map entry for the skill (undefined when global).
+ */
+export async function scopeSkill(dshHome, name, workspaces, globalLocator) {
+  const skills = await loadBindings(dshHome);
+  const binding = skills[name];
+  const storeDir = storeSkillDir(dshHome, name);
+  const storeSkillFile = join(storeDir, "SKILL.md");
+  const storeDisabledFile = storeSkillFile + DISABLED_SUFFIX;
+
+  if (workspaces === null) {
+    // → global. A skill that is already global is a no-op.
+    if (binding === undefined) return undefined;
+    const disabled = await pathExists(storeDisabledFile);
+    // Remove workspace junctions FIRST: DSH's skill watcher follows the
+    // junctions into the store and holds directory handles that block
+    // renaming the store on Windows; unlinking the junctions lets the
+    // watcher release them. Recreated on any later failure.
+    const previousLinks = binding.workspaces ?? [];
+    for (const workspace of previousLinks) await removeJunction(workspaceLink(workspace, name));
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 400));
+    let moved = false;
+    try {
+      if (binding.kind === "bundle" || binding.fileName === undefined) {
+        const target = userBundleDir(dshHome, name);
+        if (await pathExists(target)) throw new Error('目标路径已存在："' + target + '"');
+        await mkdir(dirname(target), { recursive: true });
+        moved = await movePathRetry(storeDir, target);
+      } else {
+        const fileName = disabled ? binding.fileName + DISABLED_SUFFIX : binding.fileName;
+        const target = join(dshHome, "skills", fileName);
+        if (await pathExists(target)) throw new Error('目标路径已存在："' + target + '"');
+        await mkdir(dirname(target), { recursive: true });
+        moved = await movePathRetry(disabled ? storeDisabledFile : storeSkillFile, target);
+        if (moved) await rm(storeDir, { recursive: true, force: true }).catch(() => {});
+      }
+    } catch (error) {
+      for (const workspace of previousLinks) await ensureJunction(storeDir, workspaceLink(workspace, name)).catch(() => {});
+      throw error;
+    }
+    if (!moved) {
+      for (const workspace of previousLinks) await ensureJunction(storeDir, workspaceLink(workspace, name)).catch(() => {});
+      throw new Error('技能 "' + name + '" 无法移回全局目录（文件可能被占用），已恢复原状。请稍后重试');
+    }
+    delete skills[name];
+    await saveBindings(dshHome, skills);
+    return undefined;
+  }
+
+  // → scoped to one or more workspaces.
+  const wanted = await normalizeWorkspaces(workspaces);
+  if (wanted.length === 0) throw new Error("至少需要指定一个工作区，或选择“全局”");
+
+  if (binding === undefined) {
+    // Currently global: the caller supplies the file locator in the user root.
+    if (globalLocator === undefined) throw new Error('技能 "' + name + '" 不在可管理的用户技能目录中');
+    const entry = globalLocator;
+    if (entry.file === undefined || typeof entry.file !== "string") throw new Error('技能 "' + name + '" 没有可移动的文件');
+    const disabled = entry.file.endsWith(DISABLED_SUFFIX);
+    const baseName = disabled ? entry.file.slice(0, -DISABLED_SUFFIX.length) : entry.file;
+    const fileName = basename(baseName); // SKILL.md for bundles, <file>.md for flat
+    await mkdir(storeRoot(dshHome), { recursive: true });
+    if (entry.dirBundle) {
+      // Move the whole bundle directory into the store.
+      await rename(dirname(entry.file), storeDir);
+    } else {
+      await mkdir(storeDir, { recursive: true });
+      await rename(entry.file, disabled ? storeDisabledFile : storeSkillFile);
+    }
+    const nextBinding = {
+      kind: entry.dirBundle ? "bundle" : "flat",
+      workspaces: wanted,
+      ...(!entry.dirBundle ? { fileName } : {})
+    };
+    const created = [];
+    const moveBack = entry.dirBundle
+      ? { from: storeDir, to: dirname(entry.file) }
+      : { from: disabled ? storeDisabledFile : storeSkillFile, to: entry.file, thenRemove: storeDir };
+    const undoMove = async () => {
+      try {
+        if (!(await pathExists(moveBack.from))) return;
+        if (moveBack.thenRemove !== undefined) {
+          await mkdir(dirname(moveBack.to), { recursive: true });
+          await rename(moveBack.from, moveBack.to);
+          await rm(moveBack.thenRemove, { recursive: true, force: true });
+        } else {
+          await rename(moveBack.from, moveBack.to);
+        }
+      } catch {
+        // best-effort rollback
+      }
+    };
+    try {
+      for (const workspace of wanted) {
+        await ensureJunction(storeDir, workspaceLink(workspace, name));
+        created.push(workspace);
+      }
+    } catch (error) {
+      for (const workspace of created) await removeJunction(workspaceLink(workspace, name)).catch(() => {});
+      await undoMove();
+      throw error;
+    }
+    skills[name] = nextBinding;
+    try {
+      await saveBindings(dshHome, skills);
+    } catch (error) {
+      for (const workspace of created) await removeJunction(workspaceLink(workspace, name)).catch(() => {});
+      await undoMove();
+      delete skills[name];
+      throw error;
+    }
+    return nextBinding;
+  }
+
+  // Already scoped: adjust the workspace set.
+  const previous = binding.workspaces ?? [];
+  const removed = previous.filter((workspace) => !wanted.includes(workspace));
+  const added = wanted.filter((workspace) => !previous.includes(workspace));
+  for (const workspace of removed) await removeJunction(workspaceLink(workspace, name));
+  const created = [];
+  try {
+    for (const workspace of added) {
+      await ensureJunction(storeDir, workspaceLink(workspace, name));
+      created.push(workspace);
+    }
+  } catch (error) {
+    for (const workspace of created) await removeJunction(workspaceLink(workspace, name));
+    throw error;
+  }
+  binding.workspaces = wanted;
+  await saveBindings(dshHome, skills);
+  return binding;
+}
+
+/** Best-effort undo for a failed scoping transition (unused helper kept out of the API). */
+async function rollbackLayout() {}
+
+/**
+ * Delete a scoped skill completely: junctions, stored files, and its binding.
+ * Never touches anything outside the managed store. Junctions are removed
+ * first and the store deletion retries, tolerating the provider watcher's
+ * transient directory handles.
+ */
+export async function deleteScopedSkill(dshHome, name) {
+  const skills = await loadBindings(dshHome);
+  const binding = skills[name];
+  if (binding === undefined) return false;
+  for (const workspace of binding.workspaces ?? []) await removeJunction(workspaceLink(workspace, name));
+  await new Promise((resolvePromise) => setTimeout(resolvePromise, 400));
+  const dir = storeSkillDir(dshHome, name);
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      await rm(dir, { recursive: true, force: true });
+      break;
+    } catch (error) {
+      if (!isBusyError(error) || attempt === 4) throw error;
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 300 * (attempt + 1)));
+    }
+  }
+  delete skills[name];
+  await saveBindings(dshHome, skills);
+  return true;
+}
+
+/** Whether the stored scoped skill is currently enabled (SKILL.md present). */
+export async function scopedEnabled(dshHome, name) {
+  return await pathExists(join(storeSkillDir(dshHome, name), "SKILL.md"));
+}
+
+/** Hot enable/disable a scoped skill inside the store (rename convention). */
+export async function setScopedEnabled(dshHome, name, enabled) {
+  const dir = storeSkillDir(dshHome, name);
+  const file = join(dir, "SKILL.md");
+  const disabled = file + DISABLED_SUFFIX;
+  if (enabled) {
+    if (!(await pathExists(disabled))) return false;
+    await rename(disabled, file);
+  } else {
+    if (!(await pathExists(file))) return false;
+    await rename(file, disabled);
+  }
+  return true;
+}
+
+/** Raw content of a scoped skill (enabled or disabled copy). */
+export async function scopedContent(dshHome, name) {
+  const dir = storeSkillDir(dshHome, name);
+  const file = join(dir, "SKILL.md");
+  const disabled = file + DISABLED_SUFFIX;
+  for (const candidate of [file, disabled]) {
+    try {
+      return await readFile(candidate, "utf8");
+    } catch {
+      // try the next candidate
+    }
+  }
+  return undefined;
+}

--- a/lib/skill-files.js
+++ b/lib/skill-files.js
@@ -11,10 +11,12 @@
  *   - disabled = renamed to "*.disabled"; the provider then no longer lists it.
  *   - frontmatter: YAML block between "---" lines with name + description.
  *
- * This module is dependency-free (node:fs / node:path / node:os only).
+ * This module depends only on node:fs / node:path / node:os and the `yaml`
+ * package (the same parser dsh-skill-filesystem uses for frontmatter).
  */
-import { access, readdir, readFile } from "node:fs/promises";
+import { access, readdir, readFile, stat } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
+import { parse as parseYaml } from "yaml";
 
 /** Suffix marking a hot-disabled skill file. */
 export const DISABLED_SUFFIX = ".disabled";
@@ -73,10 +75,10 @@ export function parseFrontmatter(raw) {
 
 /**
  * Strict frontmatter validation for NEW skills, mirroring the acceptance
- * rules of dsh-skill-filesystem so that invalid content is rejected before
- * anything is written:
+ * rules of dsh-skill-filesystem exactly (same YAML parser and same field
+ * policy) so that content DSH would reject never gets written:
  *   - name: required, kebab-case grammar
- *   - description: required, non-empty
+ *   - description: required, non-empty string
  *   - whenToUse: string when present
  *   - disable-model-invocation / user-invocable: boolean-ish values
  *   - legacy invocation keys are rejected
@@ -89,33 +91,34 @@ export function validateFrontmatter(raw) {
   const firstEnd = text.indexOf("\n");
   if (firstEnd === -1) return { ok: false, error: "frontmatter 未闭合" };
   const closing = text.indexOf("\n---", firstEnd + 1);
-  const fmEnd = closing === -1 ? text.length : closing;
-  const fm = text.slice(3, fmEnd);
-  const lines = fm.split("\n");
-  let name;
-  let description;
-  for (const line of lines) {
-    const match = /^([A-Za-z][A-Za-z0-9-]*):\s*(.*)$/.exec(line);
-    if (match === null) continue;
-    const key = match[1];
-    const value = match[2].trim().replace(/^["']|["']$/g, "");
-    if (key === "name") name = value;
-    else if (key === "description") description = value;
-    else if (key === "metadata" && value !== "" && !value.startsWith("{") && !value.startsWith("[")) return { ok: false, error: "metadata 必须是对象" };
-    else if (["disableModelInvocation", "modelInvocable", "userInvocable"].includes(key)) return { ok: false, error: '不支持旧字段 "' + key + '"，请改用 disable-model-invocation / user-invocable' };
-    else if (key === "disable-model-invocation" || key === "user-invocable") {
+  if (closing === -1) return { ok: false, error: "frontmatter 未闭合（缺少结尾的 ---）" };
+  const fm = text.slice(firstEnd + 1, closing);
+  let data;
+  try {
+    data = parseYaml(fm);
+  } catch (error) {
+    return { ok: false, error: "frontmatter 不是合法的 YAML：" + (error instanceof Error ? error.message : String(error)) };
+  }
+  if (data === null || typeof data !== "object" || Array.isArray(data)) return { ok: false, error: "frontmatter 必须是键值对（YAML 映射）" };
+  for (const key of ["disableModelInvocation", "modelInvocable", "userInvocable"]) {
+    if (key in data) return { ok: false, error: '不支持旧字段 "' + key + '"，请改用 disable-model-invocation / user-invocable' };
+  }
+  const name = data.name;
+  if (typeof name !== "string" || name.length === 0) return { ok: false, error: "frontmatter 缺少 name（必须是非空字符串）" };
+  if (!SKILL_NAME_RE.test(name)) return { ok: false, error: '技能名 "' + name + '" 不符合命名规则（仅小写字母、数字与连字符，如 my-skill）' };
+  const description = data.description;
+  if (typeof description !== "string" || description.trim().length === 0) return { ok: false, error: "frontmatter 缺少 description（必须是非空字符串）" };
+  const whenToUse = data.whenToUse;
+  if (whenToUse !== undefined && typeof whenToUse !== "string") return { ok: false, error: "whenToUse 必须是字符串" };
+  for (const key of ["disable-model-invocation", "user-invocable"]) {
+    const value = data[key];
+    if (value !== undefined) {
       const lower = String(value).toLowerCase();
       if (!["true", "false", "yes", "no", "on", "off", "1", "0"].includes(lower)) return { ok: false, error: key + " 必须是布尔值" };
     }
   }
-  if (typeof name !== "string" || name.length === 0) return { ok: false, error: "frontmatter 缺少 name" };
-  if (!SKILL_NAME_RE.test(name)) return { ok: false, error: '技能名 "' + name + '" 不符合命名规则（仅小写字母、数字与连字符，如 my-skill）' };
-  if (typeof description !== "string" || description.length === 0) return { ok: false, error: "frontmatter 缺少 description" };
-  const pick = (key) => {
-    const m = new RegExp("^" + key + ":\\s*(.+)$", "m").exec(fm);
-    return m === null ? undefined : m[1].trim().replace(/^["']|["']$/g, "");
-  };
-  return { ok: true, skill: { name, description, whenToUse: pick("whenToUse"), body: "" } };
+  if (data.metadata !== undefined && (typeof data.metadata !== "object" || data.metadata === null || Array.isArray(data.metadata))) return { ok: false, error: "metadata 必须是对象" };
+  return { ok: true, skill: { name, description, whenToUse: typeof whenToUse === "string" ? whenToUse : undefined, body: "" } };
 }
 
 /**
@@ -151,7 +154,8 @@ export async function buildRoots(cwd, options = {}) {
  * Collect every skill entry (enabled + disabled, bundles + flat files) under
  * the given roots. Unknown/invalid entries fall back to a name derived from
  * the directory/file name and are still reported (disabled ones must stay
- * manageable).
+ * manageable). Symlinked directories (workspace junctions pointing into the
+ * managed store) are followed, matching the provider's discovery behavior.
  */
 export async function collectSkillEntries(roots) {
   const entries = [];
@@ -163,7 +167,8 @@ export async function collectSkillEntries(roots) {
       continue; // absent root
     }
     for (const item of items) {
-      if (item.isDirectory()) {
+      const isDir = item.isDirectory() || (item.isSymbolicLink() && (await stat(join(root.path, item.name)).catch(() => undefined))?.isDirectory() === true);
+      if (isDir) {
         const md = join(root.path, item.name, "SKILL.md");
         const disabled = md + DISABLED_SUFFIX;
         if (await pathExists(md)) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-skill-viewer",
-  "version": "0.2.5",
-  "description": "dsh skill viewer: manage skills from the DSH web UI settings panel (hot enable/disable, delete, add) plus a CLI.",
+  "version": "0.2.6",
+  "description": "dsh skill viewer: manage skills from the DSH web UI settings panel (hot enable/disable, delete, add, workspace scoping) plus a CLI.",
   "type": "module",
   "main": "lib/index.js",
   "exports": {
@@ -26,6 +26,7 @@
   "dependencies": {
     "@deepseek-ai/dsh-home-paths": "^0.0.1-rc.3",
     "@deepseek-ai/dsh-typert-protocol": "^0.1.0-rc.6",
+    "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
   "bin": {

--- a/test-scope.mjs
+++ b/test-scope.mjs
@@ -1,0 +1,88 @@
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile, lstat, readlink } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  loadBindings, saveBindings, scopeSkill, normalizeWorkspaces, ensureJunction,
+  removeJunction, deleteScopedSkill, scopedEnabled, setScopedEnabled, scopedContent,
+  storeRoot, userBundleDir, workspaceLink, pruneStaleWorkspaces
+} from "./lib/scope.js";
+import { collectSkillEntries, buildRoots } from "./lib/skill-files.js";
+
+const base = await mkdtemp(join(tmpdir(), "skv-test-"));
+const dshHome = join(base, "home");
+const ws = join(base, "workspace");
+await mkdir(join(dshHome, "skills"), { recursive: true });
+await mkdir(ws, { recursive: true });
+
+const failures = [];
+function check(label, cond) {
+  console.log((cond ? "PASS" : "FAIL") + "  " + label);
+  if (!cond) failures.push(label);
+}
+
+// 1) a global bundle skill
+const skillName = "demo-skill";
+const skillBody = "---\nname: demo-skill\ndescription: 演示技能\n---\n\n# body\n";
+await mkdir(join(dshHome, "skills", skillName), { recursive: true });
+await writeFile(join(dshHome, "skills", skillName, "SKILL.md"), skillBody, "utf8");
+
+// 2) scope to one workspace
+const entry = { file: join(dshHome, "skills", skillName, "SKILL.md"), dirBundle: true, enabled: true, source: "user-dsh" };
+await scopeSkill(dshHome, skillName, [ws], entry);
+check("store dir exists after scoping", await (async () => { try { await lstat(storeRoot(dshHome) + "/" + skillName); return true; } catch { return false; } })());
+check("user root dir moved away", !(await (async () => { try { await lstat(userBundleDir(dshHome, skillName)); return true; } catch { return false; } })()));
+check("junction created in workspace", await (async () => { try { const st = await lstat(workspaceLink(ws, skillName)); return st.isSymbolicLink(); } catch { return false; } })());
+const viaLink = await readFile(join(ws, ".dsh", "skills", skillName, "SKILL.md"), "utf8");
+check("content readable through junction", viaLink.includes("demo-skill"));
+const bindings = await loadBindings(dshHome);
+check("binding recorded", bindings[skillName]?.workspaces?.includes(ws));
+
+// 3) discovery simulation: collectSkillEntries over project roots of ws
+const roots = await buildRoots(ws, { dshHome: join(base, "agents-home"), agentsHome: join(base, "agents-home-2") });
+const found = await collectSkillEntries(roots);
+check("provider-style scan finds it under project root", found.some((e) => e.name === skillName && e.enabled));
+
+// 4) enable/disable in store
+await setScopedEnabled(dshHome, skillName, false);
+check("scopedEnabled false after disable", !(await scopedEnabled(dshHome, skillName)));
+await setScopedEnabled(dshHome, skillName, true);
+check("scopedEnabled true after enable", await scopedEnabled(dshHome, skillName));
+
+// 5) content
+check("scopedContent reads body", (await scopedContent(dshHome, skillName))?.includes("# body"));
+
+// 6) back to global
+await scopeSkill(dshHome, skillName, null);
+check("restored to user root", await (async () => { try { await lstat(join(dshHome, "skills", skillName, "SKILL.md")); return true; } catch { return false; } })());
+check("junction removed", !(await (async () => { try { await lstat(workspaceLink(ws, skillName)); return true; } catch { return false; } })()));
+check("binding removed", (await loadBindings(dshHome))[skillName] === undefined);
+
+// 7) flat skill scoping + fileName restore
+await writeFile(join(dshHome, "skills", "my-flat.md"), "---\nname: my-flat\ndescription: 平铺技能\n---\n\nflat body\n", "utf8");
+await scopeSkill(dshHome, "my-flat", [ws], { file: join(dshHome, "skills", "my-flat.md"), dirBundle: false, enabled: true, source: "user-dsh" });
+check("flat stored as SKILL.md bundle", await (async () => { try { await lstat(join(storeRoot(dshHome), "my-flat", "SKILL.md")); return true; } catch { return false; } })());
+await scopeSkill(dshHome, "my-flat", null);
+check("flat restored with original file name", await (async () => { try { await lstat(join(dshHome, "skills", "my-flat.md")); return true; } catch { return false; } })());
+check("flat store cleaned", !(await (async () => { try { await lstat(join(storeRoot(dshHome), "my-flat")); return true; } catch { return false; } })()));
+
+// 8) workspace deletion pruning
+await scopeSkill(dshHome, skillName, [ws], { file: join(dshHome, "skills", skillName, "SKILL.md"), dirBundle: true, enabled: true, source: "user-dsh" });
+await rm(ws, { recursive: true, force: true });
+const b2 = await loadBindings(dshHome);
+await pruneStaleWorkspaces(dshHome, b2);
+check("stale workspace pruned", b2[skillName]?.workspaces?.length === 0);
+check("skill itself retained in store", await (async () => { try { await lstat(join(storeRoot(dshHome), skillName)); return true; } catch { return false; } })());
+
+// 9) normalizeWorkspaces errors on missing dir
+let threw = false;
+try { await normalizeWorkspaces([join(base, "nope")]); } catch { threw = true; }
+check("normalizeWorkspaces rejects missing dir", threw);
+
+// 10) deleteScopedSkill
+await deleteScopedSkill(dshHome, skillName);
+check("deleteScopedSkill removes store", !(await (async () => { try { await lstat(join(storeRoot(dshHome), skillName)); return true; } catch { return false; } })()));
+check("deleteScopedSkill removes binding", (await loadBindings(dshHome))[skillName] === undefined);
+
+await rm(base, { recursive: true, force: true }).catch(() => {});
+console.log(failures.length === 0 ? "ALL TESTS PASSED" : failures.length + " FAILURES: " + failures.join(" | "));
+process.exit(failures.length === 0 ? 0 : 1);

--- a/test-validate.mjs
+++ b/test-validate.mjs
@@ -1,0 +1,27 @@
+import { validateFrontmatter } from "./lib/skill-files.js";
+
+let failures = 0;
+const check = (label, cond) => {
+  console.log((cond ? "PASS" : "FAIL") + "  " + label);
+  if (!cond) failures++;
+};
+
+// valid basics
+check("plain frontmatter ok", validateFrontmatter("---\nname: my-skill\ndescription: 你好\n---\nbody").ok);
+// real-YAML features our old regex validator could not handle
+check("folded multiline description ok", validateFrontmatter("---\nname: my-skill\ndescription: >-\n  第一行\n  第二行\n---\nbody").ok);
+check("quoted value with colon ok", validateFrontmatter('---\nname: my-skill\ndescription: "包含:冒号"\n---\nbody').ok);
+// YAML-invalid content the old regex validator would have accepted
+check("unquoted colon in scalar rejected", !validateFrontmatter("---\nname: my-skill\ndescription: 包含: 冒号\n---\nbody").ok);
+check("invalid yaml indentation rejected", !validateFrontmatter("---\nname: my-skill\ndescription: 好\n\tbad: tab\n---\nbody").ok);
+// field policy
+check("missing name rejected", !validateFrontmatter("---\ndescription: 好\n---\nbody").ok);
+check("bad name grammar rejected", !validateFrontmatter("---\nname: My_Skill!\ndescription: 好\n---\nbody").ok);
+check("missing description rejected", !validateFrontmatter("---\nname: my-skill\n---\nbody").ok);
+check("legacy key rejected", !validateFrontmatter("---\nname: my-skill\ndescription: 好\ndisableModelInvocation: true\n---\nbody").ok);
+check("bad bool rejected", !validateFrontmatter("---\nname: my-skill\ndescription: 好\nuser-invocable: maybe\n---\nbody").ok);
+check("metadata non-object rejected", !validateFrontmatter("---\nname: my-skill\ndescription: 好\nmetadata: xyz\n---\nbody").ok);
+check("metadata object ok", validateFrontmatter("---\nname: my-skill\ndescription: 好\nmetadata:\n  a: 1\n---\nbody").ok);
+
+console.log(failures === 0 ? "ALL VALIDATOR TESTS PASSED" : failures + " FAILURES");
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Workspace scoping for skills (web UI + CLI), provider-aligned frontmatter validation, discovery fixes, Windows watcher-handle tolerance, and tests. Pushed via fork+PR because the local GitHub credential belongs to ElemmentR.