### PR TITLE
Add usage examples for both skill file formats

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,39 @@
+# 使用示例（Examples）
+
+本目录演示 `dsh-skill-viewer` 支持的两种技能文件格式，供你参考或直接拿来试手。
+
+## 目录结构
+
+```
+examples/
+├── README.md            # 本说明
+├── hello-skill/         # 目录束格式示例（含顶层 SKILL.md）
+│   └── SKILL.md
+└── hello-skill-file.md  # 单文件格式示例
+```
+
+## 两种格式怎么选
+
+| 格式 | 结构 | 适用场景 | 添加命令 |
+|---|---|---|---|
+| 单文件 | `<名字>.md` | 简单的纯指令技能 | `dsh-skill add hello-skill-file.md` |
+| 目录束 | `<名字>/SKILL.md` | 需要附带 references/scripts/assets 等资源 | `dsh-skill add hello-skill` |
+
+## 试手步骤
+
+```bash
+# 1. 添加目录束示例
+dsh-skill add examples/hello-skill
+
+# 2. 添加单文件示例
+dsh-skill add examples/hello-skill-file.md
+
+# 3. 确认都注册成功
+dsh-skill list
+
+# 4. 玩够了删掉（需确认）
+dsh-skill delete hello-skill
+dsh-skill delete hello-skill-file
+```
+
+> 提示：不合规的文件（缺少 frontmatter、`name` 不是 kebab-case 等）会被拒绝并提示原因——这两个示例都是合规的，可以故意改坏一个试试报错效果。

--- a/examples/hello-skill-file.md
+++ b/examples/hello-skill-file.md
@@ -1,0 +1,17 @@
+---
+name: hello-skill-file
+description: 演示用示例技能（单文件格式）——一个 .md 文件就是一个技能，无需目录
+---
+
+# Hello Skill File（单文件示例）
+
+这是**单文件格式**的最小示例：一个 `<名字>.md` 文件就是一个完整的技能，适合纯指令类技能，不需要附带资源。
+
+## 怎么用
+
+1. 用 `dsh-skill add examples/hello-skill-file.md` 添加到 DSH
+2. 在支持技能的 agent 会话里输入 `/hello-skill-file`，或在对话中提到本技能名
+
+## 示例指令
+
+- 模型收到本技能后，回复"你好，我是 hello-skill-file 单文件示例"，并说明单文件与目录束格式的区别。

--- a/examples/hello-skill/SKILL.md
+++ b/examples/hello-skill/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: hello-skill
+description: 演示用示例技能（目录束格式）——用最简指令展示 dsh-skill-viewer 的 bundle 结构
+---
+
+# Hello Skill（目录束示例）
+
+这是一个**目录束格式**（bundle）的最小示例：技能正文就是本文件，目录里还可以放 `references/`、`scripts/`、`assets/` 等资源目录，随技能一起被加载。
+
+## 怎么用
+
+1. 用 `dsh-skill add examples/hello-skill` 添加到 DSH
+2. 在支持技能的 agent 会话里输入 `/hello-skill`，或在对话中提到本技能名
+
+## 示例指令
+
+- 模型收到本技能后，按这里的要求行事：回复"你好，我是 hello-skill 目录束示例"，并顺带列出当前会话可用的技能清单。


### PR DESCRIPTION
新增 examples/ 目录，演示 dsh-skill-viewer 支持的两种技能格式：
- 目录束格式（hello-skill/SKILL.md）
- 单文件格式（hello-skill-file.md）

每个示例都带完整 frontmatter（kebab-case name），可直接用 dsh-skill add 添加试手，README 里附了试手步骤和格式对比表。