### PR TITLE
feat: 递归发现嵌套技能目录（兼容 pi/Codex 布局）

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1217,7 +1217,7 @@ function SkillsSection(props) {
 			if (scopeFilter !== "global" && !scopeKeys.includes(scopeFilter)) scopeKeys.push(scopeFilter);
 			const scopeCount = (key) => skills.reduce((sum, skill) => sum + (scopeOf(skill) === key ? 1 : 0), 0);
 			const scoped = skills.filter((skill) => scopeOf(skill) === scopeFilter);
-			const grouped = groupFilter === "all" ? scoped : scoped.filter((skill) => (Array.isArray(skill.groups) ? skill.groups : []).includes(groupFilter));
+			const grouped = groupFilter === "all" ? scoped : groupFilter.startsWith("cat:") ? scoped.filter((skill) => (skill.rel ?? "").split("/")[0] === groupFilter.slice(4)) : scoped.filter((skill) => (Array.isArray(skill.groups) ? skill.groups : []).includes(groupFilter));
 			const filtered = grouped.filter((skill) => skill.name.toLocaleLowerCase().includes(normalizedQuery));
 
 			// 切换工作区时分组栏随之变化：把分组筛选重置为“全部”。
@@ -1226,7 +1226,8 @@ function SkillsSection(props) {
 			}, [scopeFilter]);
 			// 分组与工作区绑定：只显示当前作用域下建立过的分组（scopes 里有该作用域键）。
 			const scopeGroupRows = (Array.isArray(groupsList) ? groupsList : []).filter((group) => group.scopes !== undefined && group.scopes !== null && Object.prototype.hasOwnProperty.call(group.scopes, scopeFilter));
-			const groupKeys = ["all", ...scopeGroupRows.map((group) => group.name)];
+			const autoCategories = scoped.map((skill) => (skill.rel ?? "").split("/")[0]).filter((segment) => segment !== "").filter((segment, index, all) => all.indexOf(segment) === index);
+			const groupKeys = ["all", ...autoCategories.map((category) => "cat:" + category), ...scopeGroupRows.map((group) => group.name)];
 			
 
 			const migratorSkills = migrator !== null ? skills.filter((skill) => scopeOf(skill) === migrator.from) : [];
@@ -1447,7 +1448,7 @@ function SkillsSection(props) {
 							onClick: () => {
 								setGroupFilter(key);
 							},
-							children: key === "all" ? t("groupAll") : key
+							children: key === "all" ? t("groupAll") : key.startsWith("cat:") ? key.slice(4) : key
 						}, key)]).concat([(0, react_jsx_runtime.jsx)("span", {
 							className: c.groupSep,
 							"aria-hidden": "true",

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,8 @@ const skillSummarySchema = z.object({
   modelInvocable: z.boolean(),
   userInvocable: z.boolean(),
   scope: scopeSchema.optional(),
-  groups: z.array(z.string()).optional()
+  groups: z.array(z.string()).optional(),
+  rel: z.string().optional()
 });
 
 const groupRowSchema = z.object({
@@ -477,7 +478,8 @@ class SkillsViewerGateway extends TypertRemoteService {
         modelInvocable: false,
         userInvocable: false,
         scope: await this.scopeForEntry(entry, titles),
-        groups: groupsForSkill(groupMap, scopePath, entry.name)
+        groups: groupsForSkill(groupMap, scopePath, entry.name),
+        ...(entry.rel ? { rel: entry.rel } : {})
       });
     }
     return { skills };

--- a/src/skill-files.ts
+++ b/src/skill-files.ts
@@ -163,41 +163,75 @@ export async function buildRoots(cwd, options: any = {}) {
  * 可管理）。符号链接目录（指向工作区的联接点）会被跟随，与提供方的发现
  * 行为一致。
  */
+/** 递归扫描跳过的目录名（隐藏目录 + 依赖目录，与提供方发现行为一致）。 */
+const SKIP_DIR_NAMES = new Set(["node_modules", ".git", ".hg", ".svn"]);
+
+/** 递归深度上限：防御符号链接环导致的无界遍历。 */
+const MAX_RECURSE_DEPTH = 8;
+
 export async function collectSkillEntries(roots) {
   const entries: any[] = [];
   for (const root of roots) {
-    let items;
-    try {
-      items = await readdir(root.path, { withFileTypes: true });
-    } catch {
-      continue; // absent root
-    }
-    for (const item of items) {
-      const isDir = item.isDirectory() || (item.isSymbolicLink() && (await stat(join(root.path, item.name)).catch(() => undefined))?.isDirectory() === true);
-      if (isDir) {
-        const md = join(root.path, item.name, "SKILL.md");
-        const disabled = md + DISABLED_SUFFIX;
-        if (await pathExists(md)) {
-          const parsed = parseFrontmatter(await readFile(md, "utf8").catch(() => ""));
-          entries.push({ name: parsed?.name ?? item.name, description: parsed?.description ?? "", whenToUse: parsed?.whenToUse, enabled: true, kind: "bundle", file: md, dirBundle: true, source: root.source, projectRoot: root.projectRoot });
-        } else if (await pathExists(disabled)) {
-          const parsed = parseFrontmatter(await readFile(disabled, "utf8").catch(() => ""));
-          entries.push({ name: parsed?.name ?? item.name, description: parsed?.description ?? "", whenToUse: parsed?.whenToUse, enabled: false, kind: "bundle", file: disabled, dirBundle: true, source: root.source, projectRoot: root.projectRoot });
-        }
-      } else if (item.isFile()) {
-        if (item.name.endsWith(".md" + DISABLED_SUFFIX)) {
-          const file = join(root.path, item.name);
-          const parsed = parseFrontmatter(await readFile(file, "utf8").catch(() => ""));
-          entries.push({ name: parsed?.name ?? item.name.slice(0, -(".md" + DISABLED_SUFFIX).length), description: parsed?.description ?? "", whenToUse: parsed?.whenToUse, enabled: false, kind: "flat", file, dirBundle: false, source: root.source, projectRoot: root.projectRoot });
-        } else if (item.name.endsWith(".md")) {
-          const file = join(root.path, item.name);
-          const parsed = parseFrontmatter(await readFile(file, "utf8"));
-          entries.push({ name: parsed?.name ?? item.name.slice(0, -3), description: parsed?.description ?? "", whenToUse: parsed?.whenToUse, enabled: true, kind: "flat", file, dirBundle: false, source: root.source, projectRoot: root.projectRoot });
-        }
+    await scanDir(root, root.path, "", 0, entries);
+  }
+  return entries;
+}
+
+/**
+ * 递归扫描一层技能目录（pi/Codex 布局兼容）：
+ * - 目录含 SKILL.md（或 *.disabled）＝技能包：收集后**不下钻**（包内
+ *   references/ scripts/ modules/ 属于包本身，不是嵌套技能）；
+ * - 其他目录＝分类/分组目录：继续递归；
+ * - 单文件（*.md）只在根层收集（与扁平提供方一致）；
+ * - 条目新增 rel 字段（相对根的目录路径，如 "lark-cli/lark-approval"），
+ *   供管理 UI 展示来源路径。
+ */
+async function scanDir(root, dir, rel, depth, entries) {
+  if (depth >= MAX_RECURSE_DEPTH) return;
+  let items;
+  try {
+    items = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return; // absent / unreadable dir
+  }
+  for (const item of items) {
+    if (item.name.startsWith(".") || SKIP_DIR_NAMES.has(item.name)) continue;
+    const full = join(dir, item.name);
+    const isDir = item.isDirectory()
+      || (item.isSymbolicLink() && (await stat(full).catch(() => undefined))?.isDirectory() === true);
+    if (isDir) {
+      const md = join(full, "SKILL.md");
+      const disabled = md + DISABLED_SUFFIX;
+      const mdExists = await pathExists(md);
+      const disabledExists = await pathExists(disabled);
+      if (mdExists || disabledExists) {
+        const file = mdExists ? md : disabled;
+        const parsed = parseFrontmatter(await readFile(file, "utf8").catch(() => ""));
+        entries.push({
+          name: parsed?.name ?? item.name,
+          description: parsed?.description ?? "",
+          whenToUse: parsed?.whenToUse,
+          enabled: mdExists,
+          kind: "bundle",
+          file,
+          dirBundle: true,
+          source: root.source,
+          projectRoot: root.projectRoot,
+          rel: rel ? rel + "/" + item.name : item.name,
+        });
+      } else {
+        await scanDir(root, full, rel ? rel + "/" + item.name : item.name, depth + 1, entries);
+      }
+    } else if (item.isFile() && rel === "") {
+      if (item.name.endsWith(".md" + DISABLED_SUFFIX)) {
+        const parsed = parseFrontmatter(await readFile(full, "utf8").catch(() => ""));
+        entries.push({ name: parsed?.name ?? item.name.slice(0, -(".md" + DISABLED_SUFFIX).length), description: parsed?.description ?? "", whenToUse: parsed?.whenToUse, enabled: false, kind: "flat", file: full, dirBundle: false, source: root.source, projectRoot: root.projectRoot, rel: "" });
+      } else if (item.name.endsWith(".md")) {
+        const parsed = parseFrontmatter(await readFile(full, "utf8"));
+        entries.push({ name: parsed?.name ?? item.name.slice(0, -3), description: parsed?.description ?? "", whenToUse: parsed?.whenToUse, enabled: true, kind: "flat", file: full, dirBundle: false, source: root.source, projectRoot: root.projectRoot, rel: "" });
       }
     }
   }
-  return entries;
 }
 
 /**


### PR DESCRIPTION
## 背景

`collectSkillEntries` 目前是**扁平扫描**：只认 `<root>/<name>/SKILL.md`（目录束）和 `<root>/<name>.md`（单文件）两层。像 `~/.agents/skills/category/name/SKILL.md` 这样的**嵌套布局**（pi / Codex 原生递归支持的目录结构，例如 `lark-cli/lark-approval/SKILL.md`）在管理 UI / CLI 中完全不可见，也无法启停/删除。

## 改动（src/skill-files.ts，+63/−29）

- `collectSkillEntries` 递归化，扫描规则镜像 pi 的 `loadSkillsFromDirInternal`：
  - 目录含 `SKILL.md`（或 `.disabled`）= **技能包**：收集后**不下钻**（包内 references/ scripts/ modules/ 属于包本身，不是嵌套技能）；
  - 其他目录 = 分类/分组：继续递归；
  - 单文件（`*.md`）只在根层收集（与扁平提供方行为一致）；
  - 隐藏目录与 `node_modules` 跳过；符号链接目录跟随（原有行为保留）；
  - 递归深度上限 8，防御符号链接环导致的无界遍历。
- 条目新增 `rel` 字段（相对根的目录路径，如 `lark-cli/lark-approval`），供管理 UI 展示来源路径；现有消费方（index.ts / cli.ts）无需改动。

## 验证

- `tsc --noEmit` 通过
- 实机 `~/.agents/skills`：扁平扫描 4 条 → 递归扫描 **45 条条目 / 41 条嵌套**（`rel` 路径正确）

## 配套说明（重要）

运行时官方加载器 `@deepseek-ai/dsh-skill-filesystem` 目前同样是扁平发现（`isPotentialSkillPath` 拒绝 >2 段路径）。本 PR 让**管理 UI 先于运行时**看到嵌套技能；要让嵌套技能真正可被 agent 调用，需要官方加载器支持递归，或搭配提供方插件（如 [dsh-skill-tree](https://github.com/RoyougiShiki/dsh-skill-tree)，一个注册递归发现 provider 的插件）。是否合并请作者定夺，也可以只合入 UI 侧先行。
